### PR TITLE
Print stack ELB

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -65,6 +65,14 @@ if (require.main === module) {
         }
     });
 
+    if (!argv._[2] && argv.stack) {
+        return Hecate.stack(argv.stack, (err, res) => {
+            if (err) throw err;
+
+            console.log(res);
+        });
+    }
+
     if (!argv._[2] || (!argv._[2] && argv.help)) {
         console.error('');
         console.error('usage: cli.js <command> [--version] [--help] [--stack <STACK NAME>]');

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "ingalls <ingalls@protonmail.com>",
   "license": "MIT",
   "bin": {
-    "hecate": "cli.js"
+    "hecatecli": "cli.js"
   },
   "devDependencies": {
     "@mapbox/eslint-config-geocoding": "^1.0.1",


### PR DESCRIPTION
Allow pretty printing stack location without a verb

```
./cli.js --stack production
```

Must be on a machine that also has access to connect to the ELB

cc/ @karenell 