### PR TITLE
Moar better docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ const hecate = new Hecate({
     port: 8000
 });
 
-hecate.auth(null, (err, res) => {
+hecate.auth({}, (err, res) => {
     if (err) throw err;
 });
 ```
@@ -126,7 +126,7 @@ const hecate = new Hecate({
     port: 8000
 });
 
-hecate.schema(null, (err, res) => {
+hecate.schema({}, (err, res) => {
     if (err) throw err;
 });
 ```
@@ -142,7 +142,5 @@ hecate.schema(null, (err, res) => {
 To Be Written
 
 ### Generate Reversion Deltas
-
-To Be Written
 
 To Be Written

--- a/README.md
+++ b/README.md
@@ -66,11 +66,42 @@ const hecate = new Hecate({
     port: 8000
 });
 
-hecate.register
+hecate.register({
+    username: 'ingalls',
+    password: 'yeaheh',
+    email: 'ingalls@protonmail.com'
+}, (err, res) => {
+    if (err) throw err;
+});
 ```
 
 **CLI**
 
 ```sh
 ./cli.js register
+```
+
+### List Server Custom Authentication
+
+See the [custom authentication](https://github.com/mapbox/Hecate#custom-authentication) section of the Hecate readme for more info
+
+**JS Library**
+
+```js
+const Hecate = require('@mapbox/hecatejs');
+
+const hecate = new Hecate({
+    url: 'example.com/hecate',
+    port: 8000
+});
+
+hecate.auth(null, (err, res) => {
+    if (err) throw err;
+});
+```
+
+**CLI**
+
+```sh
+./cli.js auth
 ```

--- a/README.md
+++ b/README.md
@@ -105,3 +105,44 @@ hecate.auth(null, (err, res) => {
 ```sh
 ./cli.js auth
 ```
+
+### Query Data
+
+To Be Written
+
+### List JSON Schema Requirements
+
+A hecate instance can optionally require that all the properties of GeoJSON features stored by the server
+conform to a given JSON Schema. Failure to meet this schema will result in the import being rejected.
+
+
+**JS Library**
+
+```js
+const Hecate = require('@mapbox/hecatejs');
+
+const hecate = new Hecate({
+    url: 'example.com/hecate',
+    port: 8000
+});
+
+hecate.schema(null, (err, res) => {
+    if (err) throw err;
+});
+```
+
+**CLI**
+
+```sh
+./cli.js schema
+```
+
+### Import Data
+
+To Be Written
+
+### Generate Reversion Deltas
+
+To Be Written
+
+To Be Written

--- a/cli.js
+++ b/cli.js
@@ -15,12 +15,21 @@ class Hecate {
         this.auth_rules = api.auth_rules ? api.auth_rules : null;
 
         // Instantiate New Library Instances
-        this.auth = new (require('./lib/auth'))(this);
-        this.query = new (require('./lib/query'))(this);
-        this.register = new (require('./lib/register'))(this);
-        this.schema = new (require('./lib/schema'))(this);
-        this.import = new (require('./lib/import'))(this);
-        this.revert = new (require('./lib/revert'))(this);
+        this._ = {
+            auth: new (require('./lib/auth'))(this),
+            query: new (require('./lib/query'))(this),
+            register: new (require('./lib/register'))(this),
+            schema: new (require('./lib/schema'))(this),
+            import: new (require('./lib/import'))(this),
+            revert: new (require('./lib/revert'))(this),
+        }
+
+        this.auth = (...opts) => this._.auth.main(...opts);
+        this.query = (...opts) => this._.query.main(...opts);
+        this.register = (...opts) => this._.register.main(...opts);
+        this.schema = (...opts) => this._.schema.main(...opts);
+        this.import = (...opts) => this._.import.main(...opts);
+        this.revert = (...opts) => this._.revert.main(...opts);
     }
 
     static stack(stack, cb) {
@@ -96,7 +105,7 @@ if (require.main === module) {
     const command = (err, hecate) => {
         if (err) throw err;
 
-        if (!hecate[argv._[2]] || !hecate[argv._[2]].cli) {
+        if (!hecate._[argv._[2]] || !hecate._[argv._[2]].cli) {
             console.error();
             console.error('subcommand not found! Run with no args for help');
             console.error();
@@ -126,12 +135,12 @@ if (require.main === module) {
             hecate.url = res.url;
             hecate.port = res.port;
 
-            hecate.auth.main(hecate, (err, auth_rules) => {
+            hecate.auth(null, (err, auth_rules) => {
                 if (err) throw err;
 
                 hecate.auth_rules = auth_rules;
 
-                hecate[argv._[2]].cli(argv);
+                hecate._[argv._[2]].cli(argv);
             });
         });
     };

--- a/cli.js
+++ b/cli.js
@@ -21,8 +21,8 @@ class Hecate {
             register: new (require('./lib/register'))(this),
             schema: new (require('./lib/schema'))(this),
             import: new (require('./lib/import'))(this),
-            revert: new (require('./lib/revert'))(this),
-        }
+            revert: new (require('./lib/revert'))(this)
+        };
 
         this.auth = (...opts) => this._.auth.main(...opts);
         this.query = (...opts) => this._.query.main(...opts);

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -26,9 +26,18 @@ class Auth {
     }
 
     main(options = {}, cb) {
+        let auth;
+        if (options.username || options.password) {
+            auth = {
+                username: options.username,
+                password: options.password
+            };
+        }
+
         request.get({
             json: true,
-            url: `http://${this.api.url}:${this.api.port}/api/auth`
+            url: `http://${this.api.url}:${this.api.port}/api/auth`,
+            auth: auth
         }, (err, res) => {
             if (err) return cb(err);
 

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -17,7 +17,7 @@ class Auth {
         console.error('');
     }
 
-    cli(options) {
+    cli(options = {}) {
         this.main(options, (err, res) => {
             if (err) throw err;
 
@@ -25,7 +25,7 @@ class Auth {
         });
     }
 
-    main(options, cb) {
+    main(options = {}, cb) {
         request.get({
             json: true,
             url: `http://${this.api.url}:${this.api.port}/api/auth`

--- a/lib/register.js
+++ b/lib/register.js
@@ -57,7 +57,7 @@ class Register {
         });
     }
 
-    main(options, cb) {
+    main(options = {}, cb) {
         if (!options.username) return cb(new Error('options.username required'));
         if (!options.password) return cb(new Error('options.password required'));
         if (!options.email) return cb(new Error('options.email required'));

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -19,7 +19,7 @@ class Schema {
         console.error('');
     }
 
-    cli(options) {
+    cli(options = {}) {
         prompt.message = '$';
         prompt.start();
 
@@ -44,7 +44,7 @@ class Schema {
         });
     }
 
-    main(options, cb) {
+    main(options = {}, cb) {
         let auth;
         if (options.username || options.password) {
             auth = {


### PR DESCRIPTION
The much expanded README will do a far better job than I can do here but to summarize the changes:

- Update README to have a skeleton to add docs to and populate the docs with a bunch of the currently written functionality
- **Breaking** Update the Hecate API to expose `main` function as a named function ie: no more `hecate.register.main`, instead `hecate.register` by loading Instantiated libs onto `hecate._.*` and then conditionally loading named functions.

Ref: https://github.com/mapbox/HecateJS/issues/3