### PR TITLE
[WIP] Add status codes to error objects

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -3,6 +3,7 @@
 'use strict';
 
 const request = require('request');
+const HTTPError = require('../util/errors').HTTPError;
 
 class Auth {
     constructor(api) {
@@ -37,16 +38,8 @@ class Auth {
         }, (err, res) => {
             if (err) return cb(err);
 
-            if (res.statusCode === 404) {
-                const error = new Error('404: Could not obtain auth list');
-                error.status = res.statusCode;
-            }
-
-            if (res.statusCode !== 200) {
-                const error = new Error(res.body);
-                error.status = res.statusCode;
-                return cb(error);
-            }
+            if (res.statusCode === 404) return cb(new HTTPError('404: Could not obtain auth list', res));
+            if (res.statusCode !== 200) return cb(new HTTPError(res.body, res));
 
             return cb(null, res.body);
         });

--- a/lib/bbox.js
+++ b/lib/bbox.js
@@ -6,6 +6,7 @@ const request = require('request');
 const prompt = require('prompt');
 const validateBbox = require('../util/validateBbox');
 const auth = require('../util/get_auth');
+const HTTPError = require('../util/errors').HTTPError;
 
 class Query {
     constructor(api) {
@@ -90,11 +91,7 @@ class Query {
             auth: this.api.user
         }, (err, res) => {
             if (err) return cb(err);
-            if (res.statusCode !== 200) {
-                const error = new Error(res.body);
-                error.status = res.statusCode;
-                return cb(error);
-            }
+            if (res.statusCode !== 200) return cb(new HTTPError(res.body, res));
             return cb(null, res.body);
         });
     }

--- a/lib/bounds.js
+++ b/lib/bounds.js
@@ -5,6 +5,7 @@
 const request = require('request');
 const prompt = require('prompt');
 const auth = require('../util/get_auth');
+const HTTPError = require('../util/errors').HTTPError;
 
 class Query {
     constructor(api) {
@@ -77,11 +78,7 @@ class Query {
             auth: this.api.user
         }, (err, res) => {
             if (err) return cb(err);
-            if (res.statusCode !== 200) {
-                const error = new Error(res.body);
-                error.status = res.statusCode;
-                return cb(error);
-            }
+            if (res.statusCode !== 200) return cb(new HTTPError(res.body, res));
             return cb(null, res.body);
         });
     }

--- a/lib/import.js
+++ b/lib/import.js
@@ -13,6 +13,7 @@ const validateGeojson = require('../util/validateGeojson.js');
 const readLineSync = require('n-readlines');
 const auth = require('../util/get_auth');
 const request = require('requestretry');
+const HTTPError = require('../util/errors').HTTPError;
 
 class ArrayReader {
     constructor(array) {
@@ -181,9 +182,7 @@ class Import {
                 if (res.statusCode !== 200) {
                     console.error(`${res.body}`);
                     console.error(`Upload Error: Uploaded to Line ${total}`);
-                    const error = new Error(res.body);
-                    error.status = res.statusCode;
-                    return cb(error);
+                    return cb(new HTTPError(res.body, res));
                 }
                 return upload_cb();
             });

--- a/lib/register.js
+++ b/lib/register.js
@@ -5,6 +5,7 @@
 const request = require('request');
 const prompt = require('prompt');
 const auth = require('../util/get_auth');
+const HTTPError = require('../util/errors').HTTPError;
 
 class Register {
 
@@ -99,11 +100,7 @@ class Register {
             auth: this.api.user
         }, (err, res) => {
             if (err) return cb(err);
-            if (res.statusCode !== 200) {
-                const error = new Error(res.body);
-                error.status = res.statusCode;
-                return cb(error);
-            }
+            if (res.statusCode !== 200) return cb(new HTTPError(res.body, res));
 
             return cb(null, true);
         });

--- a/lib/revert.js
+++ b/lib/revert.js
@@ -6,6 +6,7 @@ const async = require('async');
 const _ = require('underscore');
 const auth = require('../util/get_auth');
 const getSession = require('../util/getSession');
+const HTTPError = require('../util/errors').HTTPError;
 
 class Revert {
     constructor(api) {
@@ -59,7 +60,7 @@ class Revert {
 
             getSession(argv, (error, res) => {
                 if (error) throw error;
-                if (res.statusCode !== 200) throw new Error(res.body);
+                if (res.statusCode !== 200) throw new HTTPError(res.body, res);
                 this.main(argv, (err) => {
                     if (err) throw err;
                     console.error('Finish reversion!');
@@ -78,11 +79,8 @@ class Revert {
 
         getDelta(options, (err, res) => {
             if (err) return callback(err);
-            if (res.statusCode !== 200) {
-                const error = new Error(`Error while reverting: ${res.body}`);
-                error.status = res.statusCode;
-                return callback(error);
-            }
+            if (res.statusCode !== 200) return callback(new HTTPError(`Error while reverting: ${res.body}`, res));
+
             let featCollectionToRevert = res.body.features.features;
 
             if (featCollectionToRevert.length === 0) {
@@ -135,12 +133,7 @@ class Revert {
         async.eachSeries(featureCollection, (feature, cb) => {
             getFeatureHistory(options, feature.id, (err, response) => {
                 if (err) return callback(err);
-                if (response.statusCode !== 200) {
-                    const error = new Error(`ERROR: ${response.body.reason}`);
-                    error.status = response.statusCode;
-                    return callback(error);
-
-                }
+                if (response.statusCode !== 200) return callback(new HTTPError(`ERROR: ${response.body.reason}`, response));
                 if (response.body.length === 0) return callback(new Error('ERROR: History feature collection cannot be empty'));
 
                 const currentFeature = response.body[0].feat;

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -5,6 +5,7 @@
 const request = require('request');
 const prompt = require('prompt');
 const auth = require('../util/get_auth');
+const HTTPError = require('../util/errors').HTTPError;
 
 class Schema {
     constructor(api) {
@@ -76,11 +77,7 @@ class Schema {
             // No schema validation on server
             if (res.statusCode === 404) return cb();
 
-            if (res.statusCode !== 200) {
-                const error = new Error(res.body);
-                error.status = res.statusCode;
-                return cb(error);
-            }
+            if (res.statusCode !== 200) return cb(new HTTPError(res.body, res));
 
             return cb(null, res);
         });

--- a/test/util.errors.test.js
+++ b/test/util.errors.test.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const errors = require('../util/errors');
+const test = require('tape').test;
+
+
+test('Assert HTTPError with all parameters works as expected', (t) => {
+    const res = {
+        body: 'This is the body',
+        statusCode: 503
+    };
+
+    const httpError = new errors.HTTPError('This is an error', res);
+
+    t.ok(httpError instanceof Error, 'HTTPError is instance of Error');
+    t.equal(httpError.message, 'This is an error', 'HTTPError has the correct message');
+    t.equal(httpError.status, 503, 'HTTPError has the correct status code');
+    t.equal(httpError.name, 'HTTPError', 'HTTPError has the name "HTTPError"');
+    t.end();
+});
+
+test('Assert HTTPError with missing res parameter works as expected', (t) => {
+    const httpError = new errors.HTTPError('This is an error');
+    t.equal(httpError.status, null);
+    t.end();
+});
+

--- a/util/errors.js
+++ b/util/errors.js
@@ -1,0 +1,22 @@
+'use strict';
+/**
+ * Class to create errors that include HTTP status code
+ *
+ * @class HTTPError
+ * @extends {Error}
+ */
+class HTTPError extends Error {
+    /**
+     *Creates an instance of HTTPError.
+     * @param {string} message The error message.
+     * @param {Object} response The response object, which includes the statusCode property.
+     * @memberof HTTPError
+     */
+    constructor(message, response) {
+        super(message);
+        this.name = 'HTTPError';
+        this.status = response ? response.statusCode : null;
+    }
+}
+
+module.exports = { HTTPError };


### PR DESCRIPTION
This is work in progress to add status codes to error objects, as proposed in #15.

## Next steps
- [ ] Would love a review of the overall approach
- [ ] There are many other errors returned for things like validation of inputs. Should those also have a `status` property on them? I'm not sure what it would be, if so, because those aren't related to http responses

cc @ingalls 