### PR TITLE
Require username and password for CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ yarn global add `@mapbox/hecatejs'
 <details>
 
 Note: if the username & password is not explicitly set, Hecate will fallback to checking for
-a `HECATE_USERNAME` & `HECATE_PASSWORD` environment variable.
+a `HECATE_USERNAME` & `HECATE_PASSWORD` environment variable. For the `url` parameter, be sure to include the protocol and (if necessary) port number.
 
 **JS Library**
 
@@ -33,29 +33,26 @@ const Hecate = require('@mapbox/hecatejs');
 const hecate = new Hecate({
     username: 'ingalls',
     password: 'yeaheh',
-    url: 'example.com/hecate',
-    port: 8000
+    url: 'https://example.com/hecate',
 });
 ```
 
 **CLI**
 
 The CLI tool must be provided the URL to connect to for each subcommand.
-This can be accomplished by manually setting the URL/Port or by letting it
-query for Hecate resources on a signed in AWS account.
+This can be accomplished by providing the URL to a local or remote Hecate server. Be sure to include the protocol and, for local connections, the port number.
 
-
-The --url/port or --stack options must be provided for every subcommand
-but are omitted in this guide for clarity.
+The --url option must be provided for every subcommand but is omitted in this guide for clarity.
 
 ```sh
-./cli.js --url 'example.com' --port 8000
+# Connecting to a remote hecate server
+./cli.js --url 'https://example.com'
 ```
 
 ```sh
-./cli.js --stack buildings
+# Connecting to a local hecate server
+./cli.js --url 'http://localhost:8000'
 ```
-_Would find the AWS ELB for a CloudFormation stack called `hecate-internal-buildings`_
 
 </details>
 

--- a/cli.js
+++ b/cli.js
@@ -77,7 +77,7 @@ class Hecate {
             if (!elb.length || elb.length > 1) throw new Error('Could not find a single matching ELB Endpoint');
             elb = elb[0].OutputValue;
 
-            request(`http://${elb}`, (err, res) => {
+            request(`https://${elb}`, (err, res) => {
                 if (err) throw new Error('Failed to connect to ELB, are you in the same VPC?');
 
                 if (res.statusCode !== 200) throw new Error('Connected but recieved status code: ' + res.statusCode);

--- a/cli.js
+++ b/cli.js
@@ -198,7 +198,7 @@ if (require.main === module) {
                     // fetch auth
                     hecate.auth({}, (err, auth_rules) => {
                         // if requesting auth returns a 401
-                        if (err.message === '401: Unauthorized') {
+                        if (err && err.message === '401: Unauthorized') {
                             // if username and password isn't set, prompt for it
                             if (!hecate.user) {
                                 prompt.get(auth(hecate.user), (err, res) => {
@@ -215,10 +215,7 @@ if (require.main === module) {
                                     });
                                 });
                             } else {
-                                console.error();
-                                console.error(`user ${hecate.user.username} is unauthorized to accesss /auth endpoint`);
-                                console.error();
-                                process.exit(1);
+                                return run();
                             }
                         } else {
                             hecate.auth_rules = auth_rules;

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -57,6 +57,7 @@ class Auth {
                 if (err) return cb(err);
 
                 if (res.statusCode === 404) return cb(new Error('404: Could not obtain auth list'));
+                if (res.statusCode === 401) return cb(new Error('401: Unauthorized'));
                 if (res.statusCode !== 200) return cb(new Error(JSON.stringify(res.body)));
 
                 return cb(null, res.body);

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -51,7 +51,7 @@ class Auth {
         function main() {
             request.get({
                 json: true,
-                url: `http://${self.api.url}:${self.api.port}/api/auth`,
+                url: `https://${self.api.url}:${self.api.port}/api/auth`,
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -51,7 +51,7 @@ class Auth {
         function main() {
             request.get({
                 json: true,
-                url: `https://${self.api.url}:${self.api.port}/api/auth`,
+                url: `${self.api.url}/api/auth`,
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -57,7 +57,7 @@ class Auth {
                 if (err) return cb(err);
 
                 if (res.statusCode === 404) return cb(new Error('404: Could not obtain auth list'));
-                if (res.statusCode !== 200) return cb(new Error(res.body));
+                if (res.statusCode !== 200) return cb(new Error(JSON.stringify(res.body)));
 
                 return cb(null, res.body);
             });

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -51,7 +51,7 @@ class Auth {
         function main() {
             request.get({
                 json: true,
-                url: `${self.api.url}/api/auth`,
+                url: new URL('/api/auth', self.api.url),
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);

--- a/lib/bbox.js
+++ b/lib/bbox.js
@@ -104,7 +104,7 @@ class BBox {
             }).on('error', (err) => {
                 return cb(err);
             }).on('response', (res) => {
-                if (res.statusCode !== 200) return cb(new Error('Non-200 status code'));
+                if (res.statusCode !== 200) return cb(new Error(JSON.stringify(res.body)));
             }).pipe(new EOT(cb)).pipe(options.output);
         }
 

--- a/lib/bbox.js
+++ b/lib/bbox.js
@@ -5,6 +5,7 @@
 const request = require('request');
 const prompt = require('prompt');
 const validateBbox = require('../util/validateBbox');
+const auth = require('../util/get_auth');
 const EOT = require('../util/eot');
 
 /**
@@ -58,7 +59,7 @@ class BBox {
                 stdout: process.stderr
             });
 
-            const args = [{
+            let args = [{
                 name: 'bbox',
                 message: 'bbox to download',
                 required: true,
@@ -66,8 +67,19 @@ class BBox {
                 default: options.bbox
             }];
 
+            if (!self.api.user && self.api.auth_rules && self.api.auth_rules.feature.get !== 'public') {
+                args = args.concat(auth(self.api.user));
+            }
+
             prompt.get(args, (err, argv) => {
                 prompt.stop();
+
+                if (argv.hecate_username) {
+                    self.api.user = {
+                        username: argv.hecate_username,
+                        password: argv.hecate_password
+                    };
+                }
 
                 options.bbox = argv.bbox;
                 options.output = process.stdout;

--- a/lib/bbox.js
+++ b/lib/bbox.js
@@ -5,7 +5,6 @@
 const request = require('request');
 const prompt = require('prompt');
 const validateBbox = require('../util/validateBbox');
-const auth = require('../util/get_auth');
 const EOT = require('../util/eot');
 
 /**
@@ -59,7 +58,7 @@ class BBox {
                 stdout: process.stderr
             });
 
-            let args = [{
+            const args = [{
                 name: 'bbox',
                 message: 'bbox to download',
                 required: true,
@@ -67,19 +66,8 @@ class BBox {
                 default: options.bbox
             }];
 
-            if (self.api.auth_rules && self.api.auth_rules.feature.get !== 'public') {
-                args = args.concat(auth(self.api.user));
-            }
-
             prompt.get(args, (err, argv) => {
                 prompt.stop();
-
-                if (argv.hecate_username) {
-                    self.api.user = {
-                        username: argv.hecate_username,
-                        password: argv.hecate_password
-                    };
-                }
 
                 options.bbox = argv.bbox;
                 options.output = process.stdout;

--- a/lib/bbox.js
+++ b/lib/bbox.js
@@ -99,7 +99,7 @@ class BBox {
 
             request({
                 method: 'GET',
-                url: `https://${self.api.url}:${self.api.port}/api/data/features?bbox=${options.bbox}`,
+                url: `${self.api.url}/api/data/features?bbox=${options.bbox}`,
                 auth: self.api.user
             }).on('error', (err) => {
                 return cb(err);

--- a/lib/bbox.js
+++ b/lib/bbox.js
@@ -99,7 +99,7 @@ class BBox {
 
             request({
                 method: 'GET',
-                url: `${self.api.url}/api/data/features?bbox=${options.bbox}`,
+                url: new URL(`/api/data/features?bbox=${options.bbox}`, self.api.url),
                 auth: self.api.user
             }).on('error', (err) => {
                 return cb(err);

--- a/lib/bbox.js
+++ b/lib/bbox.js
@@ -99,7 +99,7 @@ class BBox {
 
             request({
                 method: 'GET',
-                url: `http://${self.api.url}:${self.api.port}/api/data/features?bbox=${options.bbox}`,
+                url: `https://${self.api.url}:${self.api.port}/api/data/features?bbox=${options.bbox}`,
                 auth: self.api.user
             }).on('error', (err) => {
                 return cb(err);

--- a/lib/bounds.js
+++ b/lib/bounds.js
@@ -95,7 +95,7 @@ class Bounds {
             request({
                 method: 'GET',
                 json: true,
-                url: `${self.api.url}/api/data/bounds/${options.bound}/stats`,
+                url: new URL(`/api/data/bounds/${options.bound}/stats`, self.api.url),
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);
@@ -163,7 +163,7 @@ class Bounds {
             request({
                 method: 'GET',
                 json: true,
-                url: `${self.api.url}/api/data/bounds`,
+                url: new URL('/api/data/bounds', self.api.url),
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);
@@ -248,7 +248,7 @@ class Bounds {
 
             request({
                 method: 'GET',
-                url: `${self.api.url}/api/data/bounds/${options.bound}`,
+                url: new URL(`/api/data/bounds/${options.bound}`, self.api.url),
                 auth: self.api.user
             }).on('error', (err) => {
                 return cb(err);
@@ -326,7 +326,7 @@ class Bounds {
 
             request({
                 method: 'GET',
-                url: `${self.api.url}/api/data/bounds/${options.bound}/meta`,
+                url: new URL(`/api/data/bounds/${options.bound}/meta`, self.api.url),
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);
@@ -404,7 +404,7 @@ class Bounds {
 
             request({
                 method: 'DELETE',
-                url: `${self.api.url}/api/data/bounds/${options.bound}`,
+                url: new URL(`/api/data/bounds/${options.bound}`, self.api.url),
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);
@@ -492,7 +492,7 @@ class Bounds {
             request({
                 method: 'POST',
                 json: true,
-                url: `${self.api.url}/api/data/bounds/${options.bound}`,
+                url: new URL(`/api/data/bounds/${options.bound}`, self.api.url),
                 body: {
                     type: 'Feature',
                     properties: { },

--- a/lib/bounds.js
+++ b/lib/bounds.js
@@ -4,6 +4,7 @@
 
 const request = require('request');
 const prompt = require('prompt');
+const auth = require('../util/get_auth');
 const EOT = require('../util/eot');
 
 /**
@@ -56,7 +57,7 @@ class Bounds {
                 stdout: process.stderr
             });
 
-            const args = [{
+            let args = [{
                 name: 'bound',
                 message: 'bound to download',
                 required: true,
@@ -64,10 +65,22 @@ class Bounds {
                 default: options.bound
             }];
 
+            if (!self.api.user && self.api.auth_rules && self.api.auth_rules.stats.bounds !== 'public') {
+                args = args.concat(auth(self.api.user));
+            }
+
             prompt.get(args, (err, argv) => {
                 if (err) throw err;
 
                 prompt.stop();
+
+                if (argv.hecate_username) {
+                    self.api.user = {
+                        username: argv.hecate_username,
+                        password: argv.hecate_password
+                    };
+                }
+
                 options.bound = argv.bound;
 
                 return main();
@@ -111,9 +124,37 @@ class Bounds {
 
         if (!options) options = {};
 
-        if (options.script || options.cli) {
+        if (options.script) {
             cb = cli;
             return main();
+        } else if (options.cli) {
+            cb = cli;
+
+            prompt.message = '$';
+            prompt.start({
+                stdout: process.stderr
+            });
+
+            let args = [];
+
+            if (!self.api.user && self.api.auth_rules && self.api.auth_rules.bounds.list !== 'public') {
+                args = args.concat(auth(self.api.user));
+            }
+
+            prompt.get(args, (err, argv) => {
+                if (err) throw err;
+
+                prompt.stop();
+
+                if (argv.hecate_username) {
+                    self.api.user = {
+                        username: argv.hecate_username,
+                        password: argv.hecate_password
+                    };
+                }
+
+                return main();
+            });
         } else {
             return main();
         }
@@ -168,7 +209,7 @@ class Bounds {
                 stdout: process.stderr
             });
 
-            const args = [{
+            let args = [{
                 name: 'bound',
                 message: 'bound to download',
                 required: true,
@@ -176,10 +217,21 @@ class Bounds {
                 default: options.bound
             }];
 
+            if (!self.api.user && self.api.auth_rules && self.api.auth_rules.bounds.get !== 'public') {
+                args = args.concat(auth(self.api.user));
+            }
+
             prompt.get(args, (err, argv) => {
                 if (err) throw err;
 
                 prompt.stop();
+
+                if (argv.hecate_username) {
+                    self.api.user = {
+                        username: argv.hecate_username,
+                        password: argv.hecate_password
+                    };
+                }
 
                 options.output = process.stdout;
                 options.bound = argv.bound;
@@ -237,7 +289,7 @@ class Bounds {
                 stdout: process.stderr
             });
 
-            const args = [{
+            let args = [{
                 name: 'bound',
                 message: 'bound to download',
                 required: true,
@@ -245,10 +297,22 @@ class Bounds {
                 default: options.bound
             }];
 
+            if (!self.api.user && self.api.auth_rules && self.api.auth_rules.bounds.get !== 'public') {
+                args = args.concat(auth(self.api.user));
+            }
+
             prompt.get(args, (err, argv) => {
                 if (err) throw err;
 
                 prompt.stop();
+
+                if (argv.hecate_username) {
+                    self.api.user = {
+                        username: argv.hecate_username,
+                        password: argv.hecate_password
+                    };
+                }
+
                 options.bound = argv.bound;
 
                 return main();
@@ -303,7 +367,7 @@ class Bounds {
                 stdout: process.stderr
             });
 
-            const args = [{
+            let args = [{
                 name: 'bound',
                 message: 'bound to delete',
                 required: true,
@@ -311,10 +375,22 @@ class Bounds {
                 default: options.bound
             }];
 
+            if (!self.api.user && self.api.auth_rules && self.api.auth_rules.bounds.delete !== 'public') {
+                args = args.concat(auth(self.api.user));
+            }
+
             prompt.get(args, (err, argv) => {
                 if (err) throw err;
 
                 prompt.stop();
+
+                if (argv.hecate_username) {
+                    self.api.user = {
+                        username: argv.hecate_username,
+                        password: argv.hecate_password
+                    };
+                }
+
                 options.bound = argv.bound;
 
                 return main();
@@ -370,7 +446,7 @@ class Bounds {
                 stdout: process.stderr
             });
 
-            const args = [{
+            let args = [{
                 name: 'bound',
                 message: 'name of bound to create',
                 required: true,
@@ -384,10 +460,21 @@ class Bounds {
                 default: options.geometry
             }];
 
+            if (!self.api.user && self.api.auth_rules && self.api.auth_rules.bounds.create !== 'public') {
+                args = args.concat(auth(self.api.user));
+            }
+
             prompt.get(args, (err, argv) => {
                 if (err) throw err;
 
                 prompt.stop();
+
+                if (argv.hecate_username) {
+                    self.api.user = {
+                        username: argv.hecate_username,
+                        password: argv.hecate_password
+                    };
+                }
 
                 options.bound = argv.bound;
                 options.geometry = argv.geometry;

--- a/lib/bounds.js
+++ b/lib/bounds.js
@@ -95,7 +95,7 @@ class Bounds {
             request({
                 method: 'GET',
                 json: true,
-                url: `https://${self.api.url}:${self.api.port}/api/data/bounds/${options.bound}/stats`,
+                url: `${self.api.url}/api/data/bounds/${options.bound}/stats`,
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);
@@ -163,7 +163,7 @@ class Bounds {
             request({
                 method: 'GET',
                 json: true,
-                url: `https://${self.api.url}:${self.api.port}/api/data/bounds`,
+                url: `${self.api.url}/api/data/bounds`,
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);
@@ -248,7 +248,7 @@ class Bounds {
 
             request({
                 method: 'GET',
-                url: `https://${self.api.url}:${self.api.port}/api/data/bounds/${options.bound}`,
+                url: `${self.api.url}/api/data/bounds/${options.bound}`,
                 auth: self.api.user
             }).on('error', (err) => {
                 return cb(err);
@@ -326,7 +326,7 @@ class Bounds {
 
             request({
                 method: 'GET',
-                url: `https://${self.api.url}:${self.api.port}/api/data/bounds/${options.bound}/meta`,
+                url: `${self.api.url}/api/data/bounds/${options.bound}/meta`,
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);
@@ -404,7 +404,7 @@ class Bounds {
 
             request({
                 method: 'DELETE',
-                url: `https://${self.api.url}:${self.api.port}/api/data/bounds/${options.bound}`,
+                url: `${self.api.url}/api/data/bounds/${options.bound}`,
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);
@@ -492,7 +492,7 @@ class Bounds {
             request({
                 method: 'POST',
                 json: true,
-                url: `https://${self.api.url}:${self.api.port}/api/data/bounds/${options.bound}`,
+                url: `${self.api.url}/api/data/bounds/${options.bound}`,
                 body: {
                     type: 'Feature',
                     properties: { },

--- a/lib/bounds.js
+++ b/lib/bounds.js
@@ -95,7 +95,7 @@ class Bounds {
             request({
                 method: 'GET',
                 json: true,
-                url: `http://${self.api.url}:${self.api.port}/api/data/bounds/${options.bound}/stats`,
+                url: `https://${self.api.url}:${self.api.port}/api/data/bounds/${options.bound}/stats`,
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);
@@ -163,7 +163,7 @@ class Bounds {
             request({
                 method: 'GET',
                 json: true,
-                url: `http://${self.api.url}:${self.api.port}/api/data/bounds`,
+                url: `https://${self.api.url}:${self.api.port}/api/data/bounds`,
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);
@@ -248,7 +248,7 @@ class Bounds {
 
             request({
                 method: 'GET',
-                url: `http://${self.api.url}:${self.api.port}/api/data/bounds/${options.bound}`,
+                url: `https://${self.api.url}:${self.api.port}/api/data/bounds/${options.bound}`,
                 auth: self.api.user
             }).on('error', (err) => {
                 return cb(err);
@@ -326,7 +326,7 @@ class Bounds {
 
             request({
                 method: 'GET',
-                url: `http://${self.api.url}:${self.api.port}/api/data/bounds/${options.bound}/meta`,
+                url: `https://${self.api.url}:${self.api.port}/api/data/bounds/${options.bound}/meta`,
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);
@@ -404,7 +404,7 @@ class Bounds {
 
             request({
                 method: 'DELETE',
-                url: `http://${self.api.url}:${self.api.port}/api/data/bounds/${options.bound}`,
+                url: `https://${self.api.url}:${self.api.port}/api/data/bounds/${options.bound}`,
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);
@@ -492,7 +492,7 @@ class Bounds {
             request({
                 method: 'POST',
                 json: true,
-                url: `http://${self.api.url}:${self.api.port}/api/data/bounds/${options.bound}`,
+                url: `https://${self.api.url}:${self.api.port}/api/data/bounds/${options.bound}`,
                 body: {
                     type: 'Feature',
                     properties: { },

--- a/lib/bounds.js
+++ b/lib/bounds.js
@@ -99,7 +99,7 @@ class Bounds {
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);
-                if (res.statusCode !== 200) return cb(new Error(res.body));
+                if (res.statusCode !== 200) return cb(new Error(JSON.stringify(res.body)));
 
                 return cb(null, res.body);
             });
@@ -167,7 +167,7 @@ class Bounds {
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);
-                if (res.statusCode !== 200) return cb(new Error(res.body));
+                if (res.statusCode !== 200) return cb(new Error(JSON.stringify(res.body)));
 
                 return cb(null, res.body);
             });
@@ -253,7 +253,7 @@ class Bounds {
             }).on('error', (err) => {
                 return cb(err);
             }).on('response', (res) => {
-                if (res.statusCode !== 200) return cb(new Error('Non-200 status code'));
+                if (res.statusCode !== 200) return cb(new Error(JSON.stringify(res.body)));
             }).pipe(new EOT(cb)).pipe(options.output);
         }
 
@@ -330,7 +330,7 @@ class Bounds {
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);
-                if (res.statusCode !== 200) return cb(new Error(res.body));
+                if (res.statusCode !== 200) return cb(new Error(JSON.stringify(res.body)));
 
                 return cb(null, res.body);
             });
@@ -408,7 +408,7 @@ class Bounds {
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);
-                if (res.statusCode !== 200) return cb(new Error(res.body));
+                if (res.statusCode !== 200) return cb(new Error(JSON.stringify(res.body)));
 
                 return cb(null, true);
             });
@@ -501,7 +501,7 @@ class Bounds {
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);
-                if (res.statusCode !== 200) return cb(new Error(res.body));
+                if (res.statusCode !== 200) return cb(new Error(JSON.stringify(res.body)));
 
                 return cb(null, true);
             });

--- a/lib/bounds.js
+++ b/lib/bounds.js
@@ -4,7 +4,6 @@
 
 const request = require('request');
 const prompt = require('prompt');
-const auth = require('../util/get_auth');
 const EOT = require('../util/eot');
 
 /**
@@ -57,7 +56,7 @@ class Bounds {
                 stdout: process.stderr
             });
 
-            let args = [{
+            const args = [{
                 name: 'bound',
                 message: 'bound to download',
                 required: true,
@@ -65,22 +64,10 @@ class Bounds {
                 default: options.bound
             }];
 
-            if (self.api.auth_rules && self.api.auth_rules.stats.bounds !== 'public') {
-                args = args.concat(auth(self.api.user));
-            }
-
             prompt.get(args, (err, argv) => {
                 if (err) throw err;
 
                 prompt.stop();
-
-                if (argv.hecate_username) {
-                    self.api.user = {
-                        username: argv.hecate_username,
-                        password: argv.hecate_password
-                    };
-                }
-
                 options.bound = argv.bound;
 
                 return main();
@@ -124,37 +111,9 @@ class Bounds {
 
         if (!options) options = {};
 
-        if (options.script) {
+        if (options.script || options.cli) {
             cb = cli;
             return main();
-        } else if (options.cli) {
-            cb = cli;
-
-            prompt.message = '$';
-            prompt.start({
-                stdout: process.stderr
-            });
-
-            let args = [];
-
-            if (self.api.auth_rules && self.api.auth_rules.bounds.list !== 'public') {
-                args = args.concat(auth(self.api.user));
-            }
-
-            prompt.get(args, (err, argv) => {
-                if (err) throw err;
-
-                prompt.stop();
-
-                if (argv.hecate_username) {
-                    self.api.user = {
-                        username: argv.hecate_username,
-                        password: argv.hecate_password
-                    };
-                }
-
-                return main();
-            });
         } else {
             return main();
         }
@@ -209,7 +168,7 @@ class Bounds {
                 stdout: process.stderr
             });
 
-            let args = [{
+            const args = [{
                 name: 'bound',
                 message: 'bound to download',
                 required: true,
@@ -217,21 +176,10 @@ class Bounds {
                 default: options.bound
             }];
 
-            if (self.api.auth_rules && self.api.auth_rules.bounds.get !== 'public') {
-                args = args.concat(auth(self.api.user));
-            }
-
             prompt.get(args, (err, argv) => {
                 if (err) throw err;
 
                 prompt.stop();
-
-                if (argv.hecate_username) {
-                    self.api.user = {
-                        username: argv.hecate_username,
-                        password: argv.hecate_password
-                    };
-                }
 
                 options.output = process.stdout;
                 options.bound = argv.bound;
@@ -289,7 +237,7 @@ class Bounds {
                 stdout: process.stderr
             });
 
-            let args = [{
+            const args = [{
                 name: 'bound',
                 message: 'bound to download',
                 required: true,
@@ -297,22 +245,10 @@ class Bounds {
                 default: options.bound
             }];
 
-            if (self.api.auth_rules && self.api.auth_rules.bounds.get !== 'public') {
-                args = args.concat(auth(self.api.user));
-            }
-
             prompt.get(args, (err, argv) => {
                 if (err) throw err;
 
                 prompt.stop();
-
-                if (argv.hecate_username) {
-                    self.api.user = {
-                        username: argv.hecate_username,
-                        password: argv.hecate_password
-                    };
-                }
-
                 options.bound = argv.bound;
 
                 return main();
@@ -367,7 +303,7 @@ class Bounds {
                 stdout: process.stderr
             });
 
-            let args = [{
+            const args = [{
                 name: 'bound',
                 message: 'bound to delete',
                 required: true,
@@ -375,22 +311,10 @@ class Bounds {
                 default: options.bound
             }];
 
-            if (self.api.auth_rules && self.api.auth_rules.bounds.delete !== 'public') {
-                args = args.concat(auth(self.api.user));
-            }
-
             prompt.get(args, (err, argv) => {
                 if (err) throw err;
 
                 prompt.stop();
-
-                if (argv.hecate_username) {
-                    self.api.user = {
-                        username: argv.hecate_username,
-                        password: argv.hecate_password
-                    };
-                }
-
                 options.bound = argv.bound;
 
                 return main();
@@ -446,7 +370,7 @@ class Bounds {
                 stdout: process.stderr
             });
 
-            let args = [{
+            const args = [{
                 name: 'bound',
                 message: 'name of bound to create',
                 required: true,
@@ -460,21 +384,10 @@ class Bounds {
                 default: options.geometry
             }];
 
-            if (self.api.auth_rules && self.api.auth_rules.bounds.create !== 'public') {
-                args = args.concat(auth(self.api.user));
-            }
-
             prompt.get(args, (err, argv) => {
                 if (err) throw err;
 
                 prompt.stop();
-
-                if (argv.hecate_username) {
-                    self.api.user = {
-                        username: argv.hecate_username,
-                        password: argv.hecate_password
-                    };
-                }
 
                 options.bound = argv.bound;
                 options.geometry = argv.geometry;

--- a/lib/clone.js
+++ b/lib/clone.js
@@ -85,7 +85,7 @@ class Clone {
 
             request({
                 method: 'GET',
-                url: `https://${self.api.url}:${self.api.port}/api/data/clone`,
+                url: `${self.api.url}/api/data/clone`,
                 auth: self.api.user
             }).on('error', (err) => {
                 return cb(err);

--- a/lib/clone.js
+++ b/lib/clone.js
@@ -90,7 +90,7 @@ class Clone {
             }).on('error', (err) => {
                 return cb(err);
             }).on('response', (res) => {
-                if (res.statusCode !== 200) return cb(new Error(res.body));
+                if (res.statusCode !== 200) return cb(new Error(JSON.stringify(res.body)));
             }).pipe(new EOT(cb)).pipe(options.output);
         }
 

--- a/lib/clone.js
+++ b/lib/clone.js
@@ -85,7 +85,7 @@ class Clone {
 
             request({
                 method: 'GET',
-                url: `http://${self.api.url}:${self.api.port}/api/data/clone`,
+                url: `https://${self.api.url}:${self.api.port}/api/data/clone`,
                 auth: self.api.user
             }).on('error', (err) => {
                 return cb(err);

--- a/lib/clone.js
+++ b/lib/clone.js
@@ -85,7 +85,7 @@ class Clone {
 
             request({
                 method: 'GET',
-                url: `${self.api.url}/api/data/clone`,
+                url: new URL('/api/data/clone', self.api.url),
                 auth: self.api.user
             }).on('error', (err) => {
                 return cb(err);

--- a/lib/clone.js
+++ b/lib/clone.js
@@ -3,8 +3,6 @@
 'use strict';
 
 const request = require('request');
-const prompt = require('prompt');
-const auth = require('../util/get_auth');
 const EOT = require('../util/eot');
 
 /**
@@ -42,40 +40,12 @@ class Clone {
 
         if (!options) options = {};
 
-        if (options.script) {
+        if (options.script || options.cli) {
             cb = cli;
 
             options.output = process.stdout;
 
             return main();
-        } else if (options.cli) {
-            cb = cli;
-
-            prompt.message = '$';
-            prompt.start({
-                stdout: process.stderr
-            });
-
-            let args = [];
-
-            if (self.api.auth_rules && self.api.auth_rules.clone.get !== 'public') {
-                args = args.concat(auth(self.api.user));
-            }
-
-            prompt.get(args, (err, argv) => {
-                prompt.stop();
-
-                if (argv.hecate_username) {
-                    self.api.user = {
-                        username: argv.hecate_username,
-                        password: argv.hecate_password
-                    };
-                }
-
-                options.output = process.stdout;
-
-                return main();
-            });
         } else {
             return main();
         }

--- a/lib/clone.js
+++ b/lib/clone.js
@@ -3,6 +3,8 @@
 'use strict';
 
 const request = require('request');
+const prompt = require('prompt');
+const auth = require('../util/get_auth');
 const EOT = require('../util/eot');
 
 /**
@@ -40,12 +42,40 @@ class Clone {
 
         if (!options) options = {};
 
-        if (options.script || options.cli) {
+        if (options.script) {
             cb = cli;
 
             options.output = process.stdout;
 
             return main();
+        } else if (options.cli) {
+            cb = cli;
+
+            prompt.message = '$';
+            prompt.start({
+                stdout: process.stderr
+            });
+
+            let args = [];
+
+            if (!self.api.user && self.api.auth_rules && self.api.auth_rules.clone.get !== 'public') {
+                args = args.concat(auth(self.api.user));
+            }
+
+            prompt.get(args, (err, argv) => {
+                prompt.stop();
+
+                if (argv.hecate_username) {
+                    self.api.user = {
+                        username: argv.hecate_username,
+                        password: argv.hecate_password
+                    };
+                }
+
+                options.output = process.stdout;
+
+                return main();
+            });
         } else {
             return main();
         }

--- a/lib/deltas.js
+++ b/lib/deltas.js
@@ -4,7 +4,6 @@
 
 const request = require('request');
 const prompt = require('prompt');
-const auth = require('../util/get_auth');
 
 /**
  * @class Deltas
@@ -54,7 +53,7 @@ class Deltas {
                 stdout: process.stderr
             });
 
-            let args = [{
+            const args = [{
                 name: 'limit',
                 message: 'number of deltas to retrieve',
                 required: true,
@@ -62,22 +61,10 @@ class Deltas {
                 default: options.limit
             }];
 
-            if (self.api.auth_rules && self.api.auth_rules.delta.list !== 'public') {
-                args = args.concat(auth(self.api.user));
-            }
-
             prompt.get(args, (err, argv) => {
                 if (err) throw err;
 
                 prompt.stop();
-
-                if (argv.hecate_username) {
-                    self.api.user = {
-                        username: argv.hecate_username,
-                        password: argv.hecate_password
-                    };
-                }
-
                 options.limit = argv.limit;
 
                 return main();
@@ -132,7 +119,7 @@ class Deltas {
                 stdout: process.stderr
             });
 
-            let args = [{
+            const args = [{
                 name: 'delta',
                 message: 'ID of delta to retrieve',
                 required: true,
@@ -140,22 +127,10 @@ class Deltas {
                 default: options.delta
             }];
 
-            if (self.api.auth_rules && self.api.auth_rules.delta.list !== 'public') {
-                args = args.concat(auth(self.api.user));
-            }
-
             prompt.get(args, (err, argv) => {
                 if (err) throw err;
 
                 prompt.stop();
-
-                if (argv.hecate_username) {
-                    self.api.user = {
-                        username: argv.hecate_username,
-                        password: argv.hecate_password
-                    };
-                }
-
                 options.delta = argv.delta;
 
                 return main();

--- a/lib/deltas.js
+++ b/lib/deltas.js
@@ -4,6 +4,7 @@
 
 const request = require('request');
 const prompt = require('prompt');
+const auth = require('../util/get_auth');
 
 /**
  * @class Deltas
@@ -53,7 +54,7 @@ class Deltas {
                 stdout: process.stderr
             });
 
-            const args = [{
+            let args = [{
                 name: 'limit',
                 message: 'number of deltas to retrieve',
                 required: true,
@@ -61,10 +62,22 @@ class Deltas {
                 default: options.limit
             }];
 
+            if (!self.api.user && self.api.auth_rules && self.api.auth_rules.delta.list !== 'public') {
+                args = args.concat(auth(self.api.user));
+            }
+
             prompt.get(args, (err, argv) => {
                 if (err) throw err;
 
                 prompt.stop();
+
+                if (argv.hecate_username) {
+                    self.api.user = {
+                        username: argv.hecate_username,
+                        password: argv.hecate_password
+                    };
+                }
+
                 options.limit = argv.limit;
 
                 return main();
@@ -119,7 +132,7 @@ class Deltas {
                 stdout: process.stderr
             });
 
-            const args = [{
+            let args = [{
                 name: 'delta',
                 message: 'ID of delta to retrieve',
                 required: true,
@@ -127,10 +140,22 @@ class Deltas {
                 default: options.delta
             }];
 
+            if (!self.api.user && self.api.auth_rules && self.api.auth_rules.delta.list !== 'public') {
+                args = args.concat(auth(self.api.user));
+            }
+
             prompt.get(args, (err, argv) => {
                 if (err) throw err;
 
                 prompt.stop();
+
+                if (argv.hecate_username) {
+                    self.api.user = {
+                        username: argv.hecate_username,
+                        password: argv.hecate_password
+                    };
+                }
+
                 options.delta = argv.delta;
 
                 return main();

--- a/lib/deltas.js
+++ b/lib/deltas.js
@@ -95,7 +95,8 @@ class Deltas {
                 url: `http://${self.api.url}:${self.api.port}/api/deltas?limit=${options.limit}`,
                 auth: self.api.user
             }, (err, res) => {
-                if (res.statusCode !== 200) return cb(new Error(res.body));
+                if (err) return cb(err);
+                if (res.statusCode !== 200) return cb(new Error(JSON.stringify(res.body)));
 
                 return cb(err, res.body);
             });
@@ -172,7 +173,8 @@ class Deltas {
                 url: `http://${self.api.url}:${self.api.port}/api/delta/${options.delta}`,
                 auth: self.api.user
             }, (err, res) => {
-                if (res.statusCode !== 200) return cb(new Error(res.body));
+                if (err) return cb(err);
+                if (res.statusCode !== 200) return cb(new Error(JSON.stringify(res.body)));
 
                 return cb(err, res.body);
             });

--- a/lib/deltas.js
+++ b/lib/deltas.js
@@ -92,7 +92,7 @@ class Deltas {
             request({
                 json: true,
                 method: 'GET',
-                url: `${self.api.url}/api/deltas?limit=${options.limit}`,
+                url: new URL(`/api/deltas?limit=${options.limit}`, self.api.url),
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);
@@ -170,7 +170,7 @@ class Deltas {
             request({
                 json: true,
                 method: 'GET',
-                url: `${self.api.url}/api/delta/${options.delta}`,
+                url: new URL(`/api/delta/${options.delta}`, self.api.url),
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);

--- a/lib/deltas.js
+++ b/lib/deltas.js
@@ -92,7 +92,7 @@ class Deltas {
             request({
                 json: true,
                 method: 'GET',
-                url: `http://${self.api.url}:${self.api.port}/api/deltas?limit=${options.limit}`,
+                url: `https://${self.api.url}:${self.api.port}/api/deltas?limit=${options.limit}`,
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);
@@ -170,7 +170,7 @@ class Deltas {
             request({
                 json: true,
                 method: 'GET',
-                url: `http://${self.api.url}:${self.api.port}/api/delta/${options.delta}`,
+                url: `https://${self.api.url}:${self.api.port}/api/delta/${options.delta}`,
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);

--- a/lib/deltas.js
+++ b/lib/deltas.js
@@ -92,7 +92,7 @@ class Deltas {
             request({
                 json: true,
                 method: 'GET',
-                url: `https://${self.api.url}:${self.api.port}/api/deltas?limit=${options.limit}`,
+                url: `${self.api.url}/api/deltas?limit=${options.limit}`,
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);
@@ -170,7 +170,7 @@ class Deltas {
             request({
                 json: true,
                 method: 'GET',
-                url: `https://${self.api.url}:${self.api.port}/api/delta/${options.delta}`,
+                url: `${self.api.url}/api/delta/${options.delta}`,
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);

--- a/lib/feature.js
+++ b/lib/feature.js
@@ -92,7 +92,7 @@ class Feature {
             request({
                 json: true,
                 method: 'GET',
-                url: `http://${self.api.url}:${self.api.port}/api/data/feature/${options.feature}/history`,
+                url: `https://${self.api.url}:${self.api.port}/api/data/feature/${options.feature}/history`,
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);
@@ -172,7 +172,7 @@ class Feature {
             request({
                 json: true,
                 method: 'GET',
-                url: `http://${self.api.url}:${self.api.port}/api/data/feature?key=${encodeURIComponent(options.feature)}`,
+                url: `https://${self.api.url}:${self.api.port}/api/data/feature?key=${encodeURIComponent(options.feature)}`,
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);
@@ -252,7 +252,7 @@ class Feature {
             request({
                 json: true,
                 method: 'GET',
-                url: `http://${self.api.url}:${self.api.port}/api/data/feature/${options.feature}`,
+                url: `https://${self.api.url}:${self.api.port}/api/data/feature/${options.feature}`,
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);

--- a/lib/feature.js
+++ b/lib/feature.js
@@ -92,7 +92,7 @@ class Feature {
             request({
                 json: true,
                 method: 'GET',
-                url: `${self.api.url}/api/data/feature/${options.feature}/history`,
+                url: new URL(`/api/data/feature/${options.feature}/history`, self.api.url),
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);
@@ -172,7 +172,7 @@ class Feature {
             request({
                 json: true,
                 method: 'GET',
-                url: `${self.api.url}/api/data/feature?key=${encodeURIComponent(options.feature)}`,
+                url: new URL(`/api/data/feature?key=${encodeURIComponent(options.feature)}`, self.api.url),
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);
@@ -252,7 +252,7 @@ class Feature {
             request({
                 json: true,
                 method: 'GET',
-                url: `${self.api.url}/api/data/feature/${options.feature}`,
+                url: new URL(`/api/data/feature/${options.feature}`, self.api.url),
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);

--- a/lib/feature.js
+++ b/lib/feature.js
@@ -95,7 +95,8 @@ class Feature {
                 url: `http://${self.api.url}:${self.api.port}/api/data/feature/${options.feature}/history`,
                 auth: self.api.user
             }, (err, res) => {
-                if (res.statusCode !== 200) return cb(new Error(res.body));
+                if (err) return cb(err);
+                if (res.statusCode !== 200) return cb(new Error(JSON.stringify(res.body)));
 
                 return cb(err, res.body);
             });
@@ -174,7 +175,8 @@ class Feature {
                 url: `http://${self.api.url}:${self.api.port}/api/data/feature?key=${encodeURIComponent(options.feature)}`,
                 auth: self.api.user
             }, (err, res) => {
-                if (res.statusCode !== 200) return cb(new Error(res.body));
+                if (err) return cb(err);
+                if (res.statusCode !== 200) return cb(new Error(JSON.stringify(res.body)));
 
                 return cb(err, res.body);
             });
@@ -253,7 +255,8 @@ class Feature {
                 url: `http://${self.api.url}:${self.api.port}/api/data/feature/${options.feature}`,
                 auth: self.api.user
             }, (err, res) => {
-                if (res.statusCode !== 200) return cb(new Error(res.body));
+                if (err) return cb(err);
+                if (res.statusCode !== 200) return cb(new Error(JSON.stringify(res.body)));
 
                 return cb(err, res.body);
             });

--- a/lib/feature.js
+++ b/lib/feature.js
@@ -92,7 +92,7 @@ class Feature {
             request({
                 json: true,
                 method: 'GET',
-                url: `https://${self.api.url}:${self.api.port}/api/data/feature/${options.feature}/history`,
+                url: `${self.api.url}/api/data/feature/${options.feature}/history`,
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);
@@ -172,7 +172,7 @@ class Feature {
             request({
                 json: true,
                 method: 'GET',
-                url: `https://${self.api.url}:${self.api.port}/api/data/feature?key=${encodeURIComponent(options.feature)}`,
+                url: `${self.api.url}/api/data/feature?key=${encodeURIComponent(options.feature)}`,
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);
@@ -252,7 +252,7 @@ class Feature {
             request({
                 json: true,
                 method: 'GET',
-                url: `https://${self.api.url}:${self.api.port}/api/data/feature/${options.feature}`,
+                url: `${self.api.url}/api/data/feature/${options.feature}`,
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);

--- a/lib/feature.js
+++ b/lib/feature.js
@@ -4,6 +4,7 @@
 
 const request = require('request');
 const prompt = require('prompt');
+const auth = require('../util/get_auth');
 
 /**
  * @class Feature
@@ -53,7 +54,7 @@ class Feature {
                 stdout: process.stderr
             });
 
-            const args = [{
+            let args = [{
                 name: 'feature',
                 message: 'feature id to download',
                 required: true,
@@ -61,10 +62,22 @@ class Feature {
                 default: options.feature
             }];
 
+            if (!self.api.user && self.api.auth_rules && self.api.auth_rules.feature.get !== 'public') {
+                args = args.concat(auth(self.api.user));
+            }
+
             prompt.get(args, (err, argv) => {
                 if (err) throw err;
 
                 prompt.stop();
+
+                if (argv.hecate_username) {
+                    self.api.user = {
+                        username: argv.hecate_username,
+                        password: argv.hecate_password
+                    };
+                }
+
                 options.feature = argv.feature;
 
                 return main();
@@ -121,7 +134,7 @@ class Feature {
                 stdout: process.stderr
             });
 
-            const args = [{
+            let args = [{
                 name: 'feature',
                 message: 'feature key to download',
                 required: true,
@@ -129,10 +142,22 @@ class Feature {
                 default: options.feature
             }];
 
+            if (!self.api.user && self.api.auth_rules && self.api.auth_rules.feature.get !== 'public') {
+                args = args.concat(auth(self.api.user));
+            }
+
             prompt.get(args, (err, argv) => {
                 if (err) throw err;
 
                 prompt.stop();
+
+                if (argv.hecate_username) {
+                    self.api.user = {
+                        username: argv.hecate_username,
+                        password: argv.hecate_password
+                    };
+                }
+
                 options.feature = argv.feature;
 
                 return main();
@@ -189,7 +214,7 @@ class Feature {
                 stdout: process.stderr
             });
 
-            const args = [{
+            let args = [{
                 name: 'feature',
                 message: 'feature id to download',
                 required: true,
@@ -197,10 +222,22 @@ class Feature {
                 default: options.feature
             }];
 
+            if (!self.api.user && self.api.auth_rules && self.api.auth_rules.feature.get !== 'public') {
+                args = args.concat(auth(self.api.user));
+            }
+
             prompt.get(args, (err, argv) => {
                 if (err) throw err;
 
                 prompt.stop();
+
+                if (argv.hecate_username) {
+                    self.api.user = {
+                        username: argv.hecate_username,
+                        password: argv.hecate_password
+                    };
+                }
+
                 options.feature = argv.feature;
 
                 return main();

--- a/lib/feature.js
+++ b/lib/feature.js
@@ -4,7 +4,6 @@
 
 const request = require('request');
 const prompt = require('prompt');
-const auth = require('../util/get_auth');
 
 /**
  * @class Feature
@@ -54,7 +53,7 @@ class Feature {
                 stdout: process.stderr
             });
 
-            let args = [{
+            const args = [{
                 name: 'feature',
                 message: 'feature id to download',
                 required: true,
@@ -62,22 +61,10 @@ class Feature {
                 default: options.feature
             }];
 
-            if (self.api.auth_rules && self.api.auth_rules.feature.get !== 'public') {
-                args = args.concat(auth(self.api.user));
-            }
-
             prompt.get(args, (err, argv) => {
                 if (err) throw err;
 
                 prompt.stop();
-
-                if (argv.hecate_username) {
-                    self.api.user = {
-                        username: argv.hecate_username,
-                        password: argv.hecate_password
-                    };
-                }
-
                 options.feature = argv.feature;
 
                 return main();
@@ -134,7 +121,7 @@ class Feature {
                 stdout: process.stderr
             });
 
-            let args = [{
+            const args = [{
                 name: 'feature',
                 message: 'feature key to download',
                 required: true,
@@ -142,22 +129,10 @@ class Feature {
                 default: options.feature
             }];
 
-            if (self.api.auth_rules && self.api.auth_rules.feature.get !== 'public') {
-                args = args.concat(auth(self.api.user));
-            }
-
             prompt.get(args, (err, argv) => {
                 if (err) throw err;
 
                 prompt.stop();
-
-                if (argv.hecate_username) {
-                    self.api.user = {
-                        username: argv.hecate_username,
-                        password: argv.hecate_password
-                    };
-                }
-
                 options.feature = argv.feature;
 
                 return main();
@@ -214,7 +189,7 @@ class Feature {
                 stdout: process.stderr
             });
 
-            let args = [{
+            const args = [{
                 name: 'feature',
                 message: 'feature id to download',
                 required: true,
@@ -222,22 +197,10 @@ class Feature {
                 default: options.feature
             }];
 
-            if (self.api.auth_rules && self.api.auth_rules.feature.get !== 'public') {
-                args = args.concat(auth(self.api.user));
-            }
-
             prompt.get(args, (err, argv) => {
                 if (err) throw err;
 
                 prompt.stop();
-
-                if (argv.hecate_username) {
-                    self.api.user = {
-                        username: argv.hecate_username,
-                        password: argv.hecate_password
-                    };
-                }
-
                 options.feature = argv.feature;
 
                 return main();

--- a/lib/import.js
+++ b/lib/import.js
@@ -176,7 +176,7 @@ class Import {
 
                 request({
                     method: 'POST',
-                    url: `${self.api.url}/api/data/features`,
+                    url: new URL('/api/data/features', self.api.url),
                     headers: {
                         'User-Agent': `Hecate-Internal v${config.version}`,
                         'Content-Type': 'application/json'

--- a/lib/import.js
+++ b/lib/import.js
@@ -176,7 +176,7 @@ class Import {
 
                 request({
                     method: 'POST',
-                    url: `https://${self.api.url}:${self.api.port}/api/data/features`,
+                    url: `${self.api.url}/api/data/features`,
                     headers: {
                         'User-Agent': `Hecate-Internal v${config.version}`,
                         'Content-Type': 'application/json'

--- a/lib/import.js
+++ b/lib/import.js
@@ -11,6 +11,7 @@ const prompt = require('prompt');
 const config = require('../package.json');
 const validateGeojson = require('../util/validateGeojson.js');
 const readLineSync = require('n-readlines');
+const auth = require('../util/get_auth');
 const request = require('requestretry');
 
 class ArrayReader {
@@ -70,7 +71,7 @@ class Import {
                 stdout: process.stderr
             });
 
-            const args = [{
+            let args = [{
                 name: 'message',
                 message: 'Description of changes in upload',
                 required: true,
@@ -84,8 +85,19 @@ class Import {
                 default: options.input
             }];
 
+            if (!self.api.user && self.api.auth_rules && self.api.auth_rules.feature.create !== 'public') {
+                args = args.concat(auth(self.api.user));
+            }
+
             prompt.get(args, (err, argv) => {
                 prompt.stop();
+
+                if (argv.hecate_username) {
+                    self.api.user = {
+                        username: argv.hecate_username,
+                        password: argv.hecate_password
+                    };
+                }
 
                 options.input = argv.input;
                 options.message = argv.message;

--- a/lib/import.js
+++ b/lib/import.js
@@ -11,7 +11,6 @@ const prompt = require('prompt');
 const config = require('../package.json');
 const validateGeojson = require('../util/validateGeojson.js');
 const readLineSync = require('n-readlines');
-const auth = require('../util/get_auth');
 const request = require('requestretry');
 
 class ArrayReader {
@@ -71,7 +70,7 @@ class Import {
                 stdout: process.stderr
             });
 
-            let args = [{
+            const args = [{
                 name: 'message',
                 message: 'Description of changes in upload',
                 required: true,
@@ -85,19 +84,8 @@ class Import {
                 default: options.input
             }];
 
-            if (self.api.auth_rules && self.api.auth_rules.feature.create !== 'public') {
-                args = args.concat(auth(self.api.user));
-            }
-
             prompt.get(args, (err, argv) => {
                 prompt.stop();
-
-                if (argv.hecate_username) {
-                    self.api.user = {
-                        username: argv.hecate_username,
-                        password: argv.hecate_password
-                    };
-                }
 
                 options.input = argv.input;
                 options.message = argv.message;

--- a/lib/import.js
+++ b/lib/import.js
@@ -176,7 +176,7 @@ class Import {
 
                 request({
                     method: 'POST',
-                    url: `http://${self.api.url}:${self.api.port}/api/data/features`,
+                    url: `https://${self.api.url}:${self.api.port}/api/data/features`,
                     headers: {
                         'User-Agent': `Hecate-Internal v${config.version}`,
                         'Content-Type': 'application/json'

--- a/lib/import.js
+++ b/lib/import.js
@@ -192,7 +192,7 @@ class Import {
                     if (res.statusCode !== 200) {
                         console.error(`${res.body}`);
                         console.error(`Upload Error: Uploaded to Line ${total}`);
-                        return cb(new Error(res.body));
+                        return cb(new Error(JSON.stringify(res.body)));
                     }
                     return upload_cb();
                 });

--- a/lib/revert.js
+++ b/lib/revert.js
@@ -4,6 +4,7 @@ const getDelta = require('../util/getDelta.js');
 const getFeatureHistory = require('../util/getFeatureHistory.js');
 const async = require('async');
 const _ = require('underscore');
+const auth = require('../util/get_auth');
 const getSession = require('../util/getSession');
 
 /**
@@ -38,7 +39,7 @@ class Revert {
             stdout: process.stderr
         });
 
-        const args = [{
+        let args = [{
             name: 'deltaId',
             message: 'delta id to be reverted',
             required: true,
@@ -53,7 +54,18 @@ class Revert {
             default: options.featureId
         }];
 
+        if (!self.api.user && self.api.auth_rules && self.api.auth_rules.feature.create !== 'public') {
+            args = args.concat(auth(self.api.user));
+        }
+
         prompt.get(args, (err, argv) => {
+            if (argv.hecate_username) {
+                self.api.user = {
+                    username: argv.hecate_username,
+                    password: argv.hecate_password
+                };
+            }
+
             getSession(argv, (error, res) => {
                 if (error) throw error;
                 if (res.statusCode !== 200) throw new Error(res.body);

--- a/lib/revert.js
+++ b/lib/revert.js
@@ -4,7 +4,6 @@ const getDelta = require('../util/getDelta.js');
 const getFeatureHistory = require('../util/getFeatureHistory.js');
 const async = require('async');
 const _ = require('underscore');
-const auth = require('../util/get_auth');
 const getSession = require('../util/getSession');
 
 /**
@@ -39,7 +38,7 @@ class Revert {
             stdout: process.stderr
         });
 
-        let args = [{
+        const args = [{
             name: 'deltaId',
             message: 'delta id to be reverted',
             required: true,
@@ -54,18 +53,7 @@ class Revert {
             default: options.featureId
         }];
 
-        if (self.api.auth_rules && self.api.auth_rules.feature.create !== 'public') {
-            args = args.concat(auth(self.api.user));
-        }
-
         prompt.get(args, (err, argv) => {
-            if (argv.hecate_username) {
-                self.api.user = {
-                    username: argv.hecate_username,
-                    password: argv.hecate_password
-                };
-            }
-
             getSession(argv, (error, res) => {
                 if (error) throw error;
                 if (res.statusCode !== 200) throw new Error(res.body);

--- a/lib/revert.js
+++ b/lib/revert.js
@@ -79,7 +79,6 @@ class Revert {
 
         function main() {
             if (!options.url) return callback(new Error('url is required'));
-            if (!options.port) return callback(new Error('port is required'));
             if (!options.deltaId) return callback(new Error('deltaId is required'));
 
             getDelta(options, (err, res) => {

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -75,7 +75,7 @@ class Schema {
 
                 // No schema validation on server
                 if (res.statusCode === 404) return cb();
-                if (res.statusCode !== 200) return cb(new Error(res.body));
+                if (res.statusCode !== 200) return cb(new Error(JSON.stringify(res.body)));
 
                 return cb(null, res);
             });

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -3,8 +3,6 @@
 'use strict';
 
 const request = require('request');
-const prompt = require('prompt');
-const auth = require('../util/get_auth');
 
 /**
  * @class Schema
@@ -32,35 +30,9 @@ class Schema {
         const self = this;
         if (!options) options = {};
 
-        if (options.script) {
+        if (options.script || options.cli) {
             cb = cli;
             return main();
-        } else if (options.cli) {
-            cb = cli;
-
-            prompt.message = '$';
-            prompt.start({
-                stdout: process.stderr
-            });
-
-            let args = [];
-
-            if (self.api.auth_rules && self.api.auth_rules.schema.get !== 'public') {
-                args = args.concat(auth(self.api.user));
-            }
-
-            prompt.get(args, (err, argv) => {
-                prompt.stop();
-
-                if (argv.hecate_username) {
-                    self.api.user = {
-                        username: argv.hecate_username,
-                        password: argv.hecate_password
-                    };
-                }
-
-                return main();
-            });
         } else {
             return main();
         }

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -68,7 +68,7 @@ class Schema {
         function main() {
             request.get({
                 json: true,
-                url: `${self.api.url}/api/schema`,
+                url: new URL('/api/schema', self.api.url),
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -68,7 +68,7 @@ class Schema {
         function main() {
             request.get({
                 json: true,
-                url: `http://${self.api.url}:${self.api.port}/api/schema`,
+                url: `https://${self.api.url}:${self.api.port}/api/schema`,
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -3,6 +3,8 @@
 'use strict';
 
 const request = require('request');
+const prompt = require('prompt');
+const auth = require('../util/get_auth');
 
 /**
  * @class Schema
@@ -30,9 +32,35 @@ class Schema {
         const self = this;
         if (!options) options = {};
 
-        if (options.script || options.cli) {
+        if (options.script) {
             cb = cli;
             return main();
+        } else if (options.cli) {
+            cb = cli;
+
+            prompt.message = '$';
+            prompt.start({
+                stdout: process.stderr
+            });
+
+            let args = [];
+
+            if (!self.api.user && self.api.auth_rules && self.api.auth_rules.schema.get !== 'public') {
+                args = args.concat(auth(self.api.user));
+            }
+
+            prompt.get(args, (err, argv) => {
+                prompt.stop();
+
+                if (argv.hecate_username) {
+                    self.api.user = {
+                        username: argv.hecate_username,
+                        password: argv.hecate_password
+                    };
+                }
+
+                return main();
+            });
         } else {
             return main();
         }

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -68,7 +68,7 @@ class Schema {
         function main() {
             request.get({
                 json: true,
-                url: `https://${self.api.url}:${self.api.port}/api/schema`,
+                url: `${self.api.url}/api/schema`,
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);

--- a/lib/server.js
+++ b/lib/server.js
@@ -78,7 +78,7 @@ class Server {
             request({
                 json: true,
                 method: 'GET',
-                url: `${self.api.url}/api`,
+                url: new URL('/api', self.api.url),
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);
@@ -144,7 +144,7 @@ class Server {
             request({
                 json: true,
                 method: 'GET',
-                url: `${self.api.url}/api/data/stats`,
+                url: new URL('/api/data/stats', self.api.url),
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);

--- a/lib/server.js
+++ b/lib/server.js
@@ -3,6 +3,8 @@
 'use strict';
 
 const request = require('request');
+const prompt = require('prompt');
+const auth = require('../util/get_auth');
 
 /**
  * @class Server
@@ -39,9 +41,35 @@ class Server {
 
         if (!options) options = {};
 
-        if (options.script || options.cli) {
+        if (options.script) {
             cb = cli;
             return main();
+        } else if (options.cli) {
+            cb = cli;
+
+            prompt.message = '$';
+            prompt.start({
+                stdout: process.stderr
+            });
+
+            let args = [];
+
+            if (self.api.auth_rules && self.api.auth_rules.server !== 'public') {
+                args = args.concat(auth(self.api.user));
+            }
+
+            prompt.get(args, (err, argv) => {
+                prompt.stop();
+
+                if (argv.hecate_username) {
+                    self.api.user = {
+                        username: argv.hecate_username,
+                        password: argv.hecate_password
+                    };
+                }
+
+                return main();
+            });
         } else {
             return main();
         }
@@ -79,9 +107,35 @@ class Server {
 
         if (!options) options = {};
 
-        if (options.script || options.cli) {
+        if (options.script) {
             cb = cli;
             return main();
+        } else if (options.cli) {
+            cb = cli;
+
+            prompt.message = '$';
+            prompt.start({
+                stdout: process.stderr
+            });
+
+            let args = [];
+
+            if (!self.api.user && self.api.auth_rules && self.api.auth_rules.stats.get !== 'public') {
+                args = args.concat(auth(self.api.user));
+            }
+
+            prompt.get(args, (err, argv) => {
+                prompt.stop();
+
+                if (argv.hecate_username) {
+                    self.api.user = {
+                        username: argv.hecate_username,
+                        password: argv.hecate_password
+                    };
+                }
+
+                return main();
+            });
         } else {
             return main();
         }

--- a/lib/server.js
+++ b/lib/server.js
@@ -3,8 +3,6 @@
 'use strict';
 
 const request = require('request');
-const prompt = require('prompt');
-const auth = require('../util/get_auth');
 
 /**
  * @class Server
@@ -41,35 +39,9 @@ class Server {
 
         if (!options) options = {};
 
-        if (options.script) {
+        if (options.script || options.cli) {
             cb = cli;
             return main();
-        } else if (options.cli) {
-            cb = cli;
-
-            prompt.message = '$';
-            prompt.start({
-                stdout: process.stderr
-            });
-
-            let args = [];
-
-            if (self.api.auth_rules && self.api.auth_rules.server !== 'public') {
-                args = args.concat(auth(self.api.user));
-            }
-
-            prompt.get(args, (err, argv) => {
-                prompt.stop();
-
-                if (argv.hecate_username) {
-                    self.api.user = {
-                        username: argv.hecate_username,
-                        password: argv.hecate_password
-                    };
-                }
-
-                return main();
-            });
         } else {
             return main();
         }
@@ -107,35 +79,9 @@ class Server {
 
         if (!options) options = {};
 
-        if (options.script) {
+        if (options.script || options.cli) {
             cb = cli;
             return main();
-        } else if (options.cli) {
-            cb = cli;
-
-            prompt.message = '$';
-            prompt.start({
-                stdout: process.stderr
-            });
-
-            let args = [];
-
-            if (self.api.auth_rules && self.api.auth_rules.stats.get !== 'public') {
-                args = args.concat(auth(self.api.user));
-            }
-
-            prompt.get(args, (err, argv) => {
-                prompt.stop();
-
-                if (argv.hecate_username) {
-                    self.api.user = {
-                        username: argv.hecate_username,
-                        password: argv.hecate_password
-                    };
-                }
-
-                return main();
-            });
         } else {
             return main();
         }

--- a/lib/server.js
+++ b/lib/server.js
@@ -78,7 +78,7 @@ class Server {
             request({
                 json: true,
                 method: 'GET',
-                url: `http://${self.api.url}:${self.api.port}/api`,
+                url: `https://${self.api.url}:${self.api.port}/api`,
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);
@@ -144,7 +144,7 @@ class Server {
             request({
                 json: true,
                 method: 'GET',
-                url: `http://${self.api.url}:${self.api.port}/api/data/stats`,
+                url: `https://${self.api.url}:${self.api.port}/api/data/stats`,
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);

--- a/lib/server.js
+++ b/lib/server.js
@@ -82,7 +82,7 @@ class Server {
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);
-                if (res.statusCode !== 200) return cb(new Error(res.body));
+                if (res.statusCode !== 200) return cb(new Error(JSON.stringify(res.body)));
 
                 return cb(null, res.body);
             });
@@ -148,8 +148,7 @@ class Server {
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);
-                console.error(res.body);
-                if (res.statusCode !== 200) return cb(new Error(res.body));
+                if (res.statusCode !== 200) return cb(new Error(JSON.stringify(res.body)));
 
                 return cb(null, res.body);
             });

--- a/lib/server.js
+++ b/lib/server.js
@@ -78,7 +78,7 @@ class Server {
             request({
                 json: true,
                 method: 'GET',
-                url: `https://${self.api.url}:${self.api.port}/api`,
+                url: `${self.api.url}/api`,
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);
@@ -144,7 +144,7 @@ class Server {
             request({
                 json: true,
                 method: 'GET',
-                url: `https://${self.api.url}:${self.api.port}/api/data/stats`,
+                url: `${self.api.url}/api/data/stats`,
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);

--- a/lib/tiles.js
+++ b/lib/tiles.js
@@ -4,7 +4,6 @@
 
 const request = require('request');
 const prompt = require('prompt');
-const auth = require('../util/get_auth');
 
 /**
  * @class Tiles
@@ -51,7 +50,7 @@ class Tiles {
                 stdout: process.stderr
             });
 
-            let args = [{
+            const args = [{
                 name: 'z/x/y',
                 message: 'Z/X/Y of tile to retrieve',
                 required: true,
@@ -59,22 +58,10 @@ class Tiles {
                 default: options.zxy
             }];
 
-            if (self.api.auth_rules && self.api.auth_rules.mvt.get !== 'public') {
-                args = args.concat(auth(self.api.user));
-            }
-
             prompt.get(args, (err, argv) => {
                 if (err) throw err;
 
                 prompt.stop();
-
-                if (argv.hecate_username) {
-                    self.api.user = {
-                        username: argv.hecate_username,
-                        password: argv.hecate_password
-                    };
-                }
-
                 options.limit = argv.limit;
 
                 return main();

--- a/lib/tiles.js
+++ b/lib/tiles.js
@@ -89,7 +89,7 @@ class Tiles {
             request({
                 json: true,
                 method: 'GET',
-                url: `http://${self.api.url}:${self.api.port}/api/tiles/${options.zxy}`,
+                url: `https://${self.api.url}:${self.api.port}/api/tiles/${options.zxy}`,
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);

--- a/lib/tiles.js
+++ b/lib/tiles.js
@@ -89,7 +89,7 @@ class Tiles {
             request({
                 json: true,
                 method: 'GET',
-                url: `${self.api.url}/api/tiles/${options.zxy}`,
+                url: new URL(`/api/tiles/${options.zxy}`, self.api.url),
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);

--- a/lib/tiles.js
+++ b/lib/tiles.js
@@ -4,6 +4,7 @@
 
 const request = require('request');
 const prompt = require('prompt');
+const auth = require('../util/get_auth');
 
 /**
  * @class Tiles
@@ -50,7 +51,7 @@ class Tiles {
                 stdout: process.stderr
             });
 
-            const args = [{
+            let args = [{
                 name: 'z/x/y',
                 message: 'Z/X/Y of tile to retrieve',
                 required: true,
@@ -58,10 +59,22 @@ class Tiles {
                 default: options.zxy
             }];
 
+            if (!self.api.user && self.api.auth_rules && self.api.auth_rules.mvt.get !== 'public') {
+                args = args.concat(auth(self.api.user));
+            }
+
             prompt.get(args, (err, argv) => {
                 if (err) throw err;
 
                 prompt.stop();
+
+                if (argv.hecate_username) {
+                    self.api.user = {
+                        username: argv.hecate_username,
+                        password: argv.hecate_password
+                    };
+                }
+
                 options.limit = argv.limit;
 
                 return main();

--- a/lib/tiles.js
+++ b/lib/tiles.js
@@ -92,7 +92,8 @@ class Tiles {
                 url: `http://${self.api.url}:${self.api.port}/api/tiles/${options.zxy}`,
                 auth: self.api.user
             }, (err, res) => {
-                if (res.statusCode !== 200) return cb(new Error(res.body));
+                if (err) return cb(err);
+                if (res.statusCode !== 200) return cb(new Error(JSON.stringify(res.body)));
 
                 return cb(err, res.body);
             });

--- a/lib/tiles.js
+++ b/lib/tiles.js
@@ -89,7 +89,7 @@ class Tiles {
             request({
                 json: true,
                 method: 'GET',
-                url: `https://${self.api.url}:${self.api.port}/api/tiles/${options.zxy}`,
+                url: `${self.api.url}/api/tiles/${options.zxy}`,
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);

--- a/lib/user.js
+++ b/lib/user.js
@@ -81,7 +81,7 @@ class User {
 
             request.get({
                 json: true,
-                url: `http://${self.api.url}:${self.api.port}/api/users?filter=${options.filter}`,
+                url: `https://${self.api.url}:${self.api.port}/api/users?filter=${options.filter}`,
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);
@@ -139,7 +139,7 @@ class User {
         function main() {
             request.get({
                 json: true,
-                url: `http://${self.api.url}:${self.api.port}/api/user/info`,
+                url: `https://${self.api.url}:${self.api.port}/api/user/info`,
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);
@@ -227,7 +227,7 @@ class User {
             options.email = encodeURIComponent(options.email);
 
             request.get({
-                url: `http://${self.api.url}:${self.api.port}/api/user/create?username=${options.username}&password=${options.password}&email=${options.email}`,
+                url: `https://${self.api.url}:${self.api.port}/api/user/create?username=${options.username}&password=${options.password}&email=${options.email}`,
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);

--- a/lib/user.js
+++ b/lib/user.js
@@ -81,7 +81,7 @@ class User {
 
             request.get({
                 json: true,
-                url: `${self.api.url}/api/users?filter=${options.filter}`,
+                url: new URL(`/api/users?filter=${options.filter}`, self.api.url),
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);
@@ -139,7 +139,7 @@ class User {
         function main() {
             request.get({
                 json: true,
-                url: `${self.api.url}/api/user/info`,
+                url: new URL('/api/user/info', self.api.url),
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);
@@ -227,7 +227,7 @@ class User {
             options.email = encodeURIComponent(options.email);
 
             request.get({
-                url: `${self.api.url}/api/user/create?username=${options.username}&password=${options.password}&email=${options.email}`,
+                url: new URL(`/api/user/create?username=${options.username}&password=${options.password}&email=${options.email}`, self.api.url),
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);

--- a/lib/user.js
+++ b/lib/user.js
@@ -81,7 +81,7 @@ class User {
 
             request.get({
                 json: true,
-                url: `https://${self.api.url}:${self.api.port}/api/users?filter=${options.filter}`,
+                url: `${self.api.url}/api/users?filter=${options.filter}`,
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);
@@ -139,7 +139,7 @@ class User {
         function main() {
             request.get({
                 json: true,
-                url: `https://${self.api.url}:${self.api.port}/api/user/info`,
+                url: `${self.api.url}/api/user/info`,
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);
@@ -227,7 +227,7 @@ class User {
             options.email = encodeURIComponent(options.email);
 
             request.get({
-                url: `https://${self.api.url}:${self.api.port}/api/user/create?username=${options.username}&password=${options.password}&email=${options.email}`,
+                url: `${self.api.url}/api/user/create?username=${options.username}&password=${options.password}&email=${options.email}`,
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);

--- a/lib/user.js
+++ b/lib/user.js
@@ -85,7 +85,7 @@ class User {
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);
-                if (res.statusCode !== 200) return cb(new Error(res.body));
+                if (res.statusCode !== 200) return cb(new Error(JSON.stringify(res.body)));
 
                 return cb(null, res.body);
             });
@@ -143,7 +143,7 @@ class User {
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);
-                if (res.statusCode !== 200) return cb(new Error(res.body));
+                if (res.statusCode !== 200) return cb(new Error(JSON.stringify(res.body)));
 
                 return cb(null, res.body);
             });
@@ -231,7 +231,7 @@ class User {
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);
-                if (res.statusCode !== 200) return cb(new Error(res.body));
+                if (res.statusCode !== 200) return cb(new Error(JSON.stringify(res.body)));
 
                 return cb(null, true);
             });

--- a/lib/user.js
+++ b/lib/user.js
@@ -4,6 +4,7 @@
 
 const request = require('request');
 const prompt = require('prompt');
+const auth = require('../util/get_auth');
 
 /**
  * @class User
@@ -45,7 +46,7 @@ class User {
                 stdout: process.stderr
             });
 
-            const args = [{
+            let args = [{
                 name: 'filter',
                 message: 'Optional filter prefix',
                 type: 'string',
@@ -53,8 +54,20 @@ class User {
                 default: options.filter
             }];
 
+            if (!self.api.user && self.api.auth_rules && self.api.auth_rules.user.list !== 'public') {
+                args = args.concat(auth(self.api.user));
+            }
+
             prompt.get(args, (err, argv) => {
                 prompt.stop();
+
+                if (argv.hecate_username) {
+                    self.api.user = {
+                        username: argv.hecate_username,
+                        password: argv.hecate_password
+                    };
+                }
+
                 options.filter = argv.filter;
 
                 return main();
@@ -65,6 +78,7 @@ class User {
 
         function main() {
             options.filter = options.filter ? encodeURIComponent(options.filter) : '';
+
             request.get({
                 json: true,
                 url: `http://${self.api.url}:${self.api.port}/api/users?filter=${options.filter}`,
@@ -89,9 +103,35 @@ class User {
 
         if (!options) options = {};
 
-        if (options.script || options.cli) {
+        if (options.script) {
             cb = cli;
             return main();
+        } else if (options.cli) {
+            cb = cli;
+
+            prompt.message = '$';
+            prompt.start({
+                stdout: process.stderr
+            });
+
+            let args = [];
+
+            if (!self.api.user && self.api.auth_rules && self.api.auth_rules.user.info !== 'public') {
+                args = args.concat(auth(self.api.user));
+            }
+
+            prompt.get(args, (err, argv) => {
+                prompt.stop();
+
+                if (argv.hecate_username) {
+                    self.api.user = {
+                        username: argv.hecate_username,
+                        password: argv.hecate_password
+                    };
+                }
+
+                return main();
+            });
         } else {
             return main();
         }
@@ -132,7 +172,7 @@ class User {
                 stdout: process.stderr
             });
 
-            const args = [{
+            let args = [{
                 name: 'username',
                 message: 'Your Slack/Github Username',
                 type: 'string',
@@ -153,8 +193,19 @@ class User {
                 type: 'string'
             }];
 
+            if (!self.api.user && self.api.auth_rules && self.api.auth_rules.user.create !== 'public') {
+                args = args.concat(auth(self.api.user));
+            }
+
             prompt.get(args, (err, argv) => {
                 prompt.stop();
+
+                if (argv.hecate_username) {
+                    self.api.user = {
+                        username: argv.hecate_username,
+                        password: argv.hecate_password
+                    };
+                }
 
                 options.username = argv.username;
                 options.email = argv.email;

--- a/lib/user.js
+++ b/lib/user.js
@@ -4,7 +4,6 @@
 
 const request = require('request');
 const prompt = require('prompt');
-const auth = require('../util/get_auth');
 
 /**
  * @class User
@@ -46,7 +45,7 @@ class User {
                 stdout: process.stderr
             });
 
-            let args = [{
+            const args = [{
                 name: 'filter',
                 message: 'Optional filter prefix',
                 type: 'string',
@@ -54,20 +53,8 @@ class User {
                 default: options.filter
             }];
 
-            if (self.api.auth_rules && self.api.auth_rules.user.list !== 'public') {
-                args = args.concat(auth(self.api.user));
-            }
-
             prompt.get(args, (err, argv) => {
                 prompt.stop();
-
-                if (argv.hecate_username) {
-                    self.api.user = {
-                        username: argv.hecate_username,
-                        password: argv.hecate_password
-                    };
-                }
-
                 options.filter = argv.filter;
 
                 return main();
@@ -78,7 +65,6 @@ class User {
 
         function main() {
             options.filter = options.filter ? encodeURIComponent(options.filter) : '';
-
             request.get({
                 json: true,
                 url: `http://${self.api.url}:${self.api.port}/api/users?filter=${options.filter}`,
@@ -103,35 +89,9 @@ class User {
 
         if (!options) options = {};
 
-        if (options.script) {
+        if (options.script || options.cli) {
             cb = cli;
             return main();
-        } else if (options.cli) {
-            cb = cli;
-
-            prompt.message = '$';
-            prompt.start({
-                stdout: process.stderr
-            });
-
-            let args = [];
-
-            if (self.api.auth_rules && self.api.auth_rules.user.info !== 'public') {
-                args = args.concat(auth(self.api.user));
-            }
-
-            prompt.get(args, (err, argv) => {
-                prompt.stop();
-
-                if (argv.hecate_username) {
-                    self.api.user = {
-                        username: argv.hecate_username,
-                        password: argv.hecate_password
-                    };
-                }
-
-                return main();
-            });
         } else {
             return main();
         }
@@ -172,7 +132,7 @@ class User {
                 stdout: process.stderr
             });
 
-            let args = [{
+            const args = [{
                 name: 'username',
                 message: 'Your Slack/Github Username',
                 type: 'string',
@@ -193,19 +153,8 @@ class User {
                 type: 'string'
             }];
 
-            if (self.api.auth_rules && self.api.auth_rules.user.create !== 'public') {
-                args = args.concat(auth(self.api.user));
-            }
-
             prompt.get(args, (err, argv) => {
                 prompt.stop();
-
-                if (argv.hecate_username) {
-                    self.api.user = {
-                        username: argv.hecate_username,
-                        password: argv.hecate_password
-                    };
-                }
 
                 options.username = argv.username;
                 options.email = argv.email;

--- a/lib/webhooks.js
+++ b/lib/webhooks.js
@@ -4,9 +4,7 @@
 
 const request = require('request');
 const prompt = require('prompt');
-const validateBbox = require('../util/validateBbox');
 const auth = require('../util/get_auth');
-const EOT = require('../util/eot');
 
 /**
  * @class Webhooks
@@ -29,6 +27,7 @@ class Webhooks {
         console.error('    list     List webhooks currently active on the server');
         console.error('    get      Get a specific webhook');
         console.error('    create   Create a new webhook');
+        console.error('    update   Update an existing webhook');
         console.error('    delete   Delete an existing webhook');
         console.error();
     }
@@ -82,15 +81,15 @@ class Webhooks {
         }
 
         function main() {
-            request({
-                method: 'GET',
+            request.get({
+                json: true,
                 url: `http://${self.api.url}:${self.api.port}/api/webhooks`,
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);
-                if (res.statusCode !== 200) return cb(new Error(res.body));
+                if (res.statusCode !== 200) return cb(new Error(JSON.stringify(res.body)));
 
-                return cb(null, JSON.parse(res.body));
+                return cb(null, res.body);
             });
         }
 

--- a/lib/webhooks.js
+++ b/lib/webhooks.js
@@ -4,6 +4,7 @@
 
 const request = require('request');
 const prompt = require('prompt');
+const auth = require('../util/get_auth');
 
 /**
  * @class Webhooks
@@ -43,12 +44,38 @@ class Webhooks {
 
         if (!options) options = {};
 
-        if (options.script || options.cli) {
+        if (options.script) {
             cb = cli;
 
             options.output = process.stdout;
 
             return main();
+        } else if (options.cli) {
+            cb = cli;
+
+            prompt.message = '$';
+            prompt.start({
+                stdout: process.stderr
+            });
+
+            let args = [];
+
+            if (!self.api.user && self.api.auth_rules && self.api.auth_rules.webhooks.list !== 'public') {
+                args = args.concat(auth(self.api.user));
+            }
+
+            prompt.get(args, (err, argv) => {
+                prompt.stop();
+
+                if (argv.hecate_username) {
+                    self.api.user = {
+                        username: argv.hecate_username,
+                        password: argv.hecate_password
+                    };
+                }
+
+                return main();
+            });
         } else {
             return main();
         }
@@ -100,7 +127,7 @@ class Webhooks {
                 stdout: process.stderr
             });
 
-            const args = [{
+            let args = [{
                 name: 'id',
                 message: 'Webhook ID',
                 type: 'string',
@@ -108,8 +135,19 @@ class Webhooks {
                 default: options.id
             }];
 
+            if (!self.api.user && self.api.auth_rules && self.api.auth_rules.webhooks.list !== 'public') {
+                args = args.concat(auth(self.api.user));
+            }
+
             prompt.get(args, (err, argv) => {
                 prompt.stop();
+
+                if (argv.hecate_username) {
+                    self.api.user = {
+                        username: argv.hecate_username,
+                        password: argv.hecate_password
+                    };
+                }
 
                 options.id = argv.id;
 
@@ -168,7 +206,7 @@ class Webhooks {
                 stdout: process.stderr
             });
 
-            const args = [{
+            let args = [{
                 name: 'id',
                 message: 'Webhook ID',
                 type: 'string',
@@ -176,8 +214,20 @@ class Webhooks {
                 default: options.id
             }];
 
+            if (!self.api.user && self.api.auth_rules && self.api.auth_rules.webhooks.delete !== 'public') {
+                args = args.concat(auth(self.api.user));
+            }
+
             prompt.get(args, (err, argv) => {
                 prompt.stop();
+
+                if (argv.hecate_username) {
+                    self.api.user = {
+                        username: argv.hecate_username,
+                        password: argv.hecate_password
+                    };
+                }
+
                 options.id = argv.id;
 
                 return main();
@@ -238,7 +288,7 @@ class Webhooks {
                 stdout: process.stderr
             });
 
-            const args = [{
+            let args = [{
                 name: 'id',
                 message: 'Webhook ID',
                 type: 'string',
@@ -264,8 +314,19 @@ class Webhooks {
                 default: options.actions
             }];
 
+            if (!self.api.user && self.api.auth_rules && self.api.auth_rules.webhooks.update !== 'public') {
+                args = args.concat(auth(self.api.user));
+            }
+
             prompt.get(args, (err, argv) => {
                 prompt.stop();
+
+                if (argv.hecate_username) {
+                    self.api.user = {
+                        username: argv.hecate_username,
+                        password: argv.hecate_password
+                    };
+                }
 
                 options.id = argv.id;
                 options.name = argv.name;
@@ -338,7 +399,7 @@ class Webhooks {
                 stdout: process.stderr
             });
 
-            const args = [{
+            let args = [{
                 name: 'name',
                 message: 'Webhook Name',
                 type: 'string',
@@ -358,8 +419,19 @@ class Webhooks {
                 default: options.actions
             }];
 
+            if (!self.api.user && self.api.auth_rules && self.api.auth_rules.webhooks.update !== 'public') {
+                args = args.concat(auth(self.api.user));
+            }
+
             prompt.get(args, (err, argv) => {
                 prompt.stop();
+
+                if (argv.hecate_username) {
+                    self.api.user = {
+                        username: argv.hecate_username,
+                        password: argv.hecate_password
+                    };
+                }
 
                 options.name = argv.name;
                 options.url = argv.url;

--- a/lib/webhooks.js
+++ b/lib/webhooks.js
@@ -83,7 +83,7 @@ class Webhooks {
         function main() {
             request.get({
                 json: true,
-                url: `http://${self.api.url}:${self.api.port}/api/webhooks`,
+                url: `https://${self.api.url}:${self.api.port}/api/webhooks`,
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);
@@ -162,7 +162,7 @@ class Webhooks {
 
             request({
                 method: 'GET',
-                url: `http://${self.api.url}:${self.api.port}/api/webhooks/${options.id}`,
+                url: `https://${self.api.url}:${self.api.port}/api/webhooks/${options.id}`,
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);
@@ -241,7 +241,7 @@ class Webhooks {
 
             request({
                 method: 'DELETE',
-                url: `http://${self.api.url}:${self.api.port}/api/webhooks/${options.id}`,
+                url: `https://${self.api.url}:${self.api.port}/api/webhooks/${options.id}`,
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);
@@ -348,7 +348,7 @@ class Webhooks {
             request({
                 method: 'POST',
                 json: true,
-                url: `http://${self.api.url}:${self.api.port}/api/webhooks/${options.id}`,
+                url: `https://${self.api.url}:${self.api.port}/api/webhooks/${options.id}`,
                 auth: self.api.user,
                 body: {
                     name: options.name,
@@ -451,7 +451,7 @@ class Webhooks {
             request({
                 method: 'POST',
                 json: true,
-                url: `http://${self.api.url}:${self.api.port}/api/webhooks`,
+                url: `https://${self.api.url}:${self.api.port}/api/webhooks`,
                 auth: self.api.user,
                 body: {
                     name: options.name,

--- a/lib/webhooks.js
+++ b/lib/webhooks.js
@@ -4,7 +4,6 @@
 
 const request = require('request');
 const prompt = require('prompt');
-const auth = require('../util/get_auth');
 
 /**
  * @class Webhooks
@@ -44,38 +43,12 @@ class Webhooks {
 
         if (!options) options = {};
 
-        if (options.script) {
+        if (options.script || options.cli) {
             cb = cli;
 
             options.output = process.stdout;
 
             return main();
-        } else if (options.cli) {
-            cb = cli;
-
-            prompt.message = '$';
-            prompt.start({
-                stdout: process.stderr
-            });
-
-            let args = [];
-
-            if (self.api.auth_rules && self.api.auth_rules.webhooks.list !== 'public') {
-                args = args.concat(auth(self.api.user));
-            }
-
-            prompt.get(args, (err, argv) => {
-                prompt.stop();
-
-                if (argv.hecate_username) {
-                    self.api.user = {
-                        username: argv.hecate_username,
-                        password: argv.hecate_password
-                    };
-                }
-
-                return main();
-            });
         } else {
             return main();
         }
@@ -127,7 +100,7 @@ class Webhooks {
                 stdout: process.stderr
             });
 
-            let args = [{
+            const args = [{
                 name: 'id',
                 message: 'Webhook ID',
                 type: 'string',
@@ -135,19 +108,8 @@ class Webhooks {
                 default: options.id
             }];
 
-            if (self.api.auth_rules && self.api.auth_rules.webhooks.list !== 'public') {
-                args = args.concat(auth(self.api.user));
-            }
-
             prompt.get(args, (err, argv) => {
                 prompt.stop();
-
-                if (argv.hecate_username) {
-                    self.api.user = {
-                        username: argv.hecate_username,
-                        password: argv.hecate_password
-                    };
-                }
 
                 options.id = argv.id;
 
@@ -206,7 +168,7 @@ class Webhooks {
                 stdout: process.stderr
             });
 
-            let args = [{
+            const args = [{
                 name: 'id',
                 message: 'Webhook ID',
                 type: 'string',
@@ -214,20 +176,8 @@ class Webhooks {
                 default: options.id
             }];
 
-            if (self.api.auth_rules && self.api.auth_rules.feature.delete !== 'public') {
-                args = args.concat(auth(self.api.user));
-            }
-
             prompt.get(args, (err, argv) => {
                 prompt.stop();
-
-                if (argv.hecate_username) {
-                    self.api.user = {
-                        username: argv.hecate_username,
-                        password: argv.hecate_password
-                    };
-                }
-
                 options.id = argv.id;
 
                 return main();
@@ -288,7 +238,7 @@ class Webhooks {
                 stdout: process.stderr
             });
 
-            let args = [{
+            const args = [{
                 name: 'id',
                 message: 'Webhook ID',
                 type: 'string',
@@ -314,19 +264,8 @@ class Webhooks {
                 default: options.actions
             }];
 
-            if (self.api.auth_rules && self.api.auth_rules.feature.update !== 'public') {
-                args = args.concat(auth(self.api.user));
-            }
-
             prompt.get(args, (err, argv) => {
                 prompt.stop();
-
-                if (argv.hecate_username) {
-                    self.api.user = {
-                        username: argv.hecate_username,
-                        password: argv.hecate_password
-                    };
-                }
 
                 options.id = argv.id;
                 options.name = argv.name;
@@ -399,7 +338,7 @@ class Webhooks {
                 stdout: process.stderr
             });
 
-            let args = [{
+            const args = [{
                 name: 'name',
                 message: 'Webhook Name',
                 type: 'string',
@@ -419,19 +358,8 @@ class Webhooks {
                 default: options.actions
             }];
 
-            if (self.api.auth_rules && self.api.auth_rules.feature.update !== 'public') {
-                args = args.concat(auth(self.api.user));
-            }
-
             prompt.get(args, (err, argv) => {
                 prompt.stop();
-
-                if (argv.hecate_username) {
-                    self.api.user = {
-                        username: argv.hecate_username,
-                        password: argv.hecate_password
-                    };
-                }
 
                 options.name = argv.name;
                 options.url = argv.url;

--- a/lib/webhooks.js
+++ b/lib/webhooks.js
@@ -83,7 +83,7 @@ class Webhooks {
         function main() {
             request.get({
                 json: true,
-                url: `${self.api.url}/api/webhooks`,
+                url: new URL('/api/webhooks', self.api.url),
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);
@@ -162,7 +162,7 @@ class Webhooks {
 
             request({
                 method: 'GET',
-                url: `${self.api.url}/api/webhooks/${options.id}`,
+                url: new URL(`/api/webhooks/${options.id}`, self.api.url),
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);
@@ -241,7 +241,7 @@ class Webhooks {
 
             request({
                 method: 'DELETE',
-                url: `${self.api.url}/api/webhooks/${options.id}`,
+                url: new URL(`/api/webhooks/${options.id}`, self.api.url),
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);
@@ -348,7 +348,7 @@ class Webhooks {
             request({
                 method: 'POST',
                 json: true,
-                url: `${self.api.url}/api/webhooks/${options.id}`,
+                url: new URL(`/api/webhooks/${options.id}`, self.api.url),
                 auth: self.api.user,
                 body: {
                     name: options.name,
@@ -451,7 +451,7 @@ class Webhooks {
             request({
                 method: 'POST',
                 json: true,
-                url: `${self.api.url}/api/webhooks`,
+                url: new URL('/api/webhooks', self.api.url),
                 auth: self.api.user,
                 body: {
                     name: options.name,

--- a/lib/webhooks.js
+++ b/lib/webhooks.js
@@ -83,7 +83,7 @@ class Webhooks {
         function main() {
             request.get({
                 json: true,
-                url: `https://${self.api.url}:${self.api.port}/api/webhooks`,
+                url: `${self.api.url}/api/webhooks`,
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);
@@ -162,7 +162,7 @@ class Webhooks {
 
             request({
                 method: 'GET',
-                url: `https://${self.api.url}:${self.api.port}/api/webhooks/${options.id}`,
+                url: `${self.api.url}/api/webhooks/${options.id}`,
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);
@@ -241,7 +241,7 @@ class Webhooks {
 
             request({
                 method: 'DELETE',
-                url: `https://${self.api.url}:${self.api.port}/api/webhooks/${options.id}`,
+                url: `${self.api.url}/api/webhooks/${options.id}`,
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);
@@ -348,7 +348,7 @@ class Webhooks {
             request({
                 method: 'POST',
                 json: true,
-                url: `https://${self.api.url}:${self.api.port}/api/webhooks/${options.id}`,
+                url: `${self.api.url}/api/webhooks/${options.id}`,
                 auth: self.api.user,
                 body: {
                     name: options.name,
@@ -451,7 +451,7 @@ class Webhooks {
             request({
                 method: 'POST',
                 json: true,
-                url: `https://${self.api.url}:${self.api.port}/api/webhooks`,
+                url: `${self.api.url}/api/webhooks`,
                 auth: self.api.user,
                 body: {
                     name: options.name,

--- a/test/lib.auth.test.js
+++ b/test/lib.auth.test.js
@@ -6,7 +6,7 @@ const test = require('tape').test;
 const nock = require('nock');
 
 test('lib.auth.test.js', (t) => {
-    nock('http://localhost:7777')
+    nock('https://localhost:7777')
         .get('/api/auth')
         .reply(200, {
             custom: 'auth'

--- a/test/lib.auth.test.js
+++ b/test/lib.auth.test.js
@@ -6,15 +6,14 @@ const test = require('tape').test;
 const nock = require('nock');
 
 test('lib.auth.test.js', (t) => {
-    nock('https://localhost:7777')
+    nock('http://localhost:7777')
         .get('/api/auth')
         .reply(200, {
             custom: 'auth'
         });
 
     const hecate = new Hecate({
-        url: 'localhost',
-        port: '7777'
+        url: 'http://localhost:7777'
     });
 
     hecate.auth(null, (err, res) => {

--- a/test/lib.deltas.test.js
+++ b/test/lib.deltas.test.js
@@ -6,7 +6,7 @@ const test = require('tape').test;
 const nock = require('nock');
 
 test('lib.deltas.test.js', (t) => {
-    nock('http://localhost:7777')
+    nock('https://localhost:7777')
         .get('/api/deltas?limit=100')
         .reply(200, true);
 
@@ -23,7 +23,7 @@ test('lib.deltas.test.js', (t) => {
         });
     });
 
-    nock('http://localhost:7777')
+    nock('https://localhost:7777')
         .get('/api/deltas?limit=1')
         .reply(200, true);
 

--- a/test/lib.deltas.test.js
+++ b/test/lib.deltas.test.js
@@ -6,13 +6,12 @@ const test = require('tape').test;
 const nock = require('nock');
 
 test('lib.deltas.test.js', (t) => {
-    nock('https://localhost:7777')
+    nock('http://localhost:7777')
         .get('/api/deltas?limit=100')
         .reply(200, true);
 
     const hecate = new Hecate({
-        url: 'localhost',
-        port: '7777'
+        url: 'http://localhost:7777'
     });
 
     t.test('lib.deltas.test.js - default', (q) => {
@@ -23,7 +22,7 @@ test('lib.deltas.test.js', (t) => {
         });
     });
 
-    nock('https://localhost:7777')
+    nock('http://localhost:7777')
         .get('/api/deltas?limit=1')
         .reply(200, true);
 

--- a/test/lib.register.test.js
+++ b/test/lib.register.test.js
@@ -6,7 +6,7 @@ const test = require('tape').test;
 const nock = require('nock');
 
 test('lib.register.test.js', (t) => {
-    nock('http://localhost:7777')
+    nock('https://localhost:7777')
         .get('/api/user/create?username=ingalls&password=yeaheh&email=nick%40mapbox.com')
         .reply(200, true);
 

--- a/test/lib.register.test.js
+++ b/test/lib.register.test.js
@@ -6,13 +6,12 @@ const test = require('tape').test;
 const nock = require('nock');
 
 test('lib.register.test.js', (t) => {
-    nock('https://localhost:7777')
+    nock('http://localhost:7777')
         .get('/api/user/create?username=ingalls&password=yeaheh&email=nick%40mapbox.com')
         .reply(200, true);
 
     const hecate = new Hecate({
-        url: 'localhost',
-        port: '7777'
+        url: 'http://localhost:7777'
     });
 
     t.test('lib.register.test.js - missing username', (q) => {

--- a/test/util.getDelta.test.js
+++ b/test/util.getDelta.test.js
@@ -12,7 +12,7 @@ test('Assert fails per missing arguments', (t) => {
 });
 
 test('Assert obtaining delta according to ID', (t) => {
-    nock('http://localhost:7777')
+    nock('https://localhost:7777')
         .get('/api/delta/1')
         .reply(200, 'response is as expected');
 

--- a/test/util.getDelta.test.js
+++ b/test/util.getDelta.test.js
@@ -5,20 +5,18 @@ const test = require('tape').test;
 const nock = require('nock');
 
 test('Assert fails per missing arguments', (t) => {
-    getDelta({ port: '1111', deltaId: 1 }, (err) => { t.deepEquals(err.message, 'URL is required', 'URL is required'); });
-    getDelta({ url: 'xurl', deltaId: 1 }, (err) => { t.deepEquals(err.message, 'A port is required', 'A port is required'); });
-    getDelta({ port: '1111', url: 'xurl' }, (err) => { t.deepEquals(err.message, 'A deltaId is required', 'A deltaId is required'); });
+    getDelta({ deltaId: 1 }, (err) => { t.deepEquals(err.message, 'URL is required', 'URL is required'); });
+    getDelta({ url: 'xurl' }, (err) => { t.deepEquals(err.message, 'A deltaId is required', 'A deltaId is required'); });
     t.end();
 });
 
 test('Assert obtaining delta according to ID', (t) => {
-    nock('https://localhost:7777')
+    nock('http://localhost:7777')
         .get('/api/delta/1')
         .reply(200, 'response is as expected');
 
     getDelta({
-        url: 'localhost',
-        port: '7777',
+        url: 'http://localhost:7777',
         deltaId: 1
     }, (err, res) => {
         t.equal(res.body, 'response is as expected', 'response is as expected');

--- a/test/util.getFeatureHistory.test.js
+++ b/test/util.getFeatureHistory.test.js
@@ -10,7 +10,7 @@ test('Assert fails per missing arguments', (t) => {
 });
 
 test('Assert getting a feature history list', (t) => {
-    nock('http://localhost:7777')
+    nock('https://localhost:7777')
         .get('/api/data/feature/7/history')
         .reply(200, 'response is as expected');
 

--- a/test/util.getFeatureHistory.test.js
+++ b/test/util.getFeatureHistory.test.js
@@ -5,18 +5,16 @@ const test = require('tape').test;
 const nock = require('nock');
 
 test('Assert fails per missing arguments', (t) => {
-    getFeatureHistory({ port: '1111', url: 'xurl' }, null, (err) => { t.deepEquals(err.message, 'A feature ID is required', 'A feature ID is required'); });
+    getFeatureHistory({ url: 'xurl' }, null, (err) => { t.deepEquals(err.message, 'A feature ID is required', 'A feature ID is required'); });
     t.end();
 });
 
 test('Assert getting a feature history list', (t) => {
-    nock('https://localhost:7777')
+    nock('http://localhost:7777')
         .get('/api/data/feature/7/history')
         .reply(200, 'response is as expected');
 
-    const argv = { url: 'localhost', port: '7777' };
-
-    getFeatureHistory(argv, 7, (err, res) => {
+    getFeatureHistory({ url: 'http://localhost:7777' }, 7, (err, res) => {
         t.equal(res.statusCode, 200, 'status code is 200');
         t.equal(res.body, 'response is as expected', 'response is as expected');
         t.end();

--- a/test/util.getSession.test.js
+++ b/test/util.getSession.test.js
@@ -5,21 +5,18 @@ const test = require('tape').test;
 const nock = require('nock');
 
 test('Assert fails per missing arguments', (t) => {
-    getSession({ password: 'psw', port: '1111', url: 'url' }, (err) => { t.deepEquals(err.message, 'username is required', 'username is required'); });
-    getSession({ username: 'user', port: '1111', url: 'url' }, (err) => { t.deepEquals(err.message, 'password is required', 'password is required'); });
-    getSession({ username: 'user', password: 'psw', port: '1111' }, (err) => { t.deepEquals(err.message, 'URL is required', 'URL is required'); });
-    getSession({ username: 'user', password: 'psw', url: 'url' }, (err) => { t.deepEquals(err.message, 'port is required', 'port is required'); });
+    getSession({ password: 'psw', url: 'url' }, (err) => { t.deepEquals(err.message, 'username is required', 'username is required'); });
+    getSession({ username: 'user', url: 'url' }, (err) => { t.deepEquals(err.message, 'password is required', 'password is required'); });
+    getSession({ username: 'user', password: 'psw' }, (err) => { t.deepEquals(err.message, 'URL is required', 'URL is required'); });
     t.end();
 });
 
 test('Assert obtaining session info', (t) => {
-    nock(/url:7777/)
+    nock('http://localhost:7777')
         .get('/api/user/session')
         .reply(200, 'response is as expected');
 
-    const options = { username: 'username', password: 'psw', url: 'url', port: '7777' };
-
-    getSession(options, (err, res) => {
+    getSession({ username: 'username', password: 'psw', url: 'http://localhost:7777' }, (err, res) => {
         t.equal(res.body, 'response is as expected', 'response is as expected');
         t.end();
     });

--- a/util/getDelta.js
+++ b/util/getDelta.js
@@ -12,7 +12,7 @@ function getDelta(argv, callback) {
     if (!argv.deltaId) return callback(new Error('A deltaId is required'));
 
     request({
-        url: `http://${argv.url}:${argv.port}/api/delta/${argv.deltaId}`,
+        url: `https://${argv.url}:${argv.port}/api/delta/${argv.deltaId}`,
         json: true
     }, (err, res) => {
         if (err) {

--- a/util/getDelta.js
+++ b/util/getDelta.js
@@ -8,11 +8,10 @@ const request = require('request');
 
 function getDelta(argv, callback) {
     if (!argv.url) return callback(new Error('URL is required'));
-    if (!argv.port) return callback(new Error('A port is required'));
     if (!argv.deltaId) return callback(new Error('A deltaId is required'));
 
     request({
-        url: `https://${argv.url}:${argv.port}/api/delta/${argv.deltaId}`,
+        url: new URL(`/api/delta/${argv.deltaId}`, argv.url),
         json: true
     }, (err, res) => {
         if (err) {

--- a/util/getFeatureHistory.js
+++ b/util/getFeatureHistory.js
@@ -10,7 +10,7 @@ function getFeatureHistory(argv, featureId, callback) {
     if (!featureId) return callback(new Error('A feature ID is required'));
 
     request({
-        url: `http://${argv.url}:${argv.port}/api/data/feature/${featureId}/history`,
+        url: `https://${argv.url}:${argv.port}/api/data/feature/${featureId}/history`,
         json: true
     }, (err, res) => {
         if (err) {

--- a/util/getFeatureHistory.js
+++ b/util/getFeatureHistory.js
@@ -10,7 +10,7 @@ function getFeatureHistory(argv, featureId, callback) {
     if (!featureId) return callback(new Error('A feature ID is required'));
 
     request({
-        url: `https://${argv.url}:${argv.port}/api/data/feature/${featureId}/history`,
+        url: new URL(`/api/data/feature/${featureId}/history`, argv.url),
         json: true
     }, (err, res) => {
         if (err) {

--- a/util/getSession.js
+++ b/util/getSession.js
@@ -5,11 +5,11 @@ function getSession(options, callback) {
     if (!options.username) return callback(new Error('username is required'));
     if (!options.password) return callback(new Error('password is required'));
     if (!options.url) return callback(new Error('URL is required'));
-    if (!options.port) return callback(new Error('port is required'));
 
     request({
-        url: `https://${options.username}:${options.password}@${options.url}:${options.port}/api/user/session`,
-        json: true
+        url: new URL('/api/user/session', options.url),
+        json: true,
+        auth: { username: options.username, password: options.password }
     }, (err, res) => {
         if (err) {
             console.error(`ERROR: Could not retrieve session of ${options.username}`);

--- a/util/getSession.js
+++ b/util/getSession.js
@@ -8,7 +8,7 @@ function getSession(options, callback) {
     if (!options.port) return callback(new Error('port is required'));
 
     request({
-        url: `http://${options.username}:${options.password}@${options.url}:${options.port}/api/user/session`,
+        url: `https://${options.username}:${options.password}@${options.url}:${options.port}/api/user/session`,
         json: true
     }, (err, res) => {
         if (err) {


### PR DESCRIPTION
## Context

Previously, HecateJS only prompted the user for authentication in cli mode if the endpoint was not `public` according to the permissions json retrieved from Hecate's `/auth` endpoint. As of https://github.com/mapbox/Hecate/blob/master/CHANGELOG.md#v0730, Hecate now requires authentication for every endpoint. This was causing all cli requests to fail because they couldn't retrieve the permissions json before they even began to make a request for the desired endpoint. This PR requires cli users to submit a username and password in the prompts, or set environmental variables with these values and use the [`--scripts` flag](https://github.com/mapbox/HecateJS/pull/12#issue-204112531).

## Summary of changes
- [x] prompt for auth in cli.js rather than conditionally in endpoint requests
- [x] remove retrieving the permissions json; as we've already asked the user for authentication, we don't need to conditionally ask them again
- [x] pass hecate errors to callbacks where we weren't before and better format hecate responses

## Next steps
- [ ] add tests for cli and `--script` mode

cc @mattciferri @ingalls @samely @miccolis 