### PR TITLE
Support offset parameter for listDeltas

### DIFF
--- a/lib/deltas.js
+++ b/lib/deltas.js
@@ -33,6 +33,7 @@ class Deltas {
      *
      * @param {!Object} options Options for making a request to the deltas endpoint
      * @param {String} [options.limit=100] Number of deltas to list by default
+     * @param {String} [options.offset] delta id to start listing at
      *
      * @param {function} cb (err, res) style callback function
      */
@@ -60,6 +61,11 @@ class Deltas {
                 required: true,
                 type: 'string',
                 default: options.limit
+            }, {
+                name: 'offset',
+                message: 'delta id to start listing at',
+                required: false,
+                type: 'string'
             }];
 
             if (!self.api.user && self.api.auth_rules && self.api.auth_rules.delta.list !== 'public') {
@@ -79,6 +85,7 @@ class Deltas {
                 }
 
                 options.limit = argv.limit;
+                options.offset = argv.offset || null;
 
                 return main();
             });
@@ -88,11 +95,13 @@ class Deltas {
 
         function main() {
             if (!options.limit) options.limit = 100;
-
+            const query = options.offset ?
+                `/api/deltas?limit=${options.limit}&offset=${options.offset}`
+                : `/api/deltas?limit=${options.limit}`;
             request({
                 json: true,
                 method: 'GET',
-                url: new URL(`/api/deltas?limit=${options.limit}`, self.api.url),
+                url: new URL(query, self.api.url),
                 auth: self.api.user
             }, (err, res) => {
                 if (err) return cb(err);

--- a/test/lib.deltas.test.js
+++ b/test/lib.deltas.test.js
@@ -6,13 +6,13 @@ const test = require('tape').test;
 const nock = require('nock');
 
 test('lib.deltas.test.js', (t) => {
-    nock('http://localhost:7777')
-        .get('/api/deltas?limit=100')
-        .reply(200, true);
-
     const hecate = new Hecate({
         url: 'http://localhost:7777'
     });
+
+    nock('http://localhost:7777')
+        .get('/api/deltas?limit=100')
+        .reply(200, true);
 
     t.test('lib.deltas.test.js - default', (q) => {
         hecate.listDeltas({}, (err, res) => {
@@ -26,9 +26,24 @@ test('lib.deltas.test.js', (t) => {
         .get('/api/deltas?limit=1')
         .reply(200, true);
 
-    t.test('lib.deltas.test.js - default', (q) => {
+    t.test('lib.deltas.test.js - custom limit', (q) => {
         hecate.listDeltas({
             limit: 1
+        }, (err, res) => {
+            q.error(err, 'no errors');
+            q.equals(res, true);
+            q.end();
+        });
+    });
+
+    nock('http://localhost:7777')
+        .get('/api/deltas?limit=1&offset=1')
+        .reply(200, true);
+
+    t.test('lib.deltas.test.js - custom offset', (q) => {
+        hecate.listDeltas({
+            limit: 1,
+            offset: 1
         }, (err, res) => {
             q.error(err, 'no errors');
             q.equals(res, true);


### PR DESCRIPTION
## Context

Adds support for the `offset` parameter supported by Hecate's list delta endpoint https://github.com/mapbox/hecate#get-apideltas

## Next steps
- [ ] review
- [ ] merge
- [ ] release

cc @mattciferri @ingalls @miccolis @samely 