### PR TITLE
Import Module - Duplicate ID Check

### DIFF
--- a/lib/import.js
+++ b/lib/import.js
@@ -145,7 +145,7 @@ class Import {
                         validateGeojson({
                             ignoreRHR: options.ignoreRHR,
                             schema: schema,
-                            ids: options.ignoreDup
+                            ids: !options.ignoreDup
                         }),
                         (err) => {
                             if (err) return cb(err);

--- a/lib/import.js
+++ b/lib/import.js
@@ -56,6 +56,7 @@ class Import {
         console.error('<subcommand>');
         console.error('    multi        Import multiple features');
         console.error('                 [--ignore-rhr] Ignore Right Hand Rule Errors');
+        console.error('                 [--ignore-dup] Disable duplicate ID check');
         console.error('                 [--dryrun] Perform pre-import validation checks');
         console.error('                     but do not perform import');
         console.error();
@@ -108,6 +109,7 @@ class Import {
                 options.input = argv.input;
                 options.message = argv.message;
                 options.ignoreRHR = !!options['ignore-rhr'];
+                options.ignoreDup = !!options['ignore-dup'];
                 options.dryrun = !!options.dryrun;
 
                 return main();
@@ -143,6 +145,7 @@ class Import {
                         validateGeojson({
                             ignoreRHR: options.ignoreRHR,
                             schema: schema
+                            ids: options.ignoreDup
                         }),
                         (err) => {
                             if (err) return cb(err);

--- a/lib/import.js
+++ b/lib/import.js
@@ -144,7 +144,7 @@ class Import {
                         split(),
                         validateGeojson({
                             ignoreRHR: options.ignoreRHR,
-                            schema: schema
+                            schema: schema,
                             ids: options.ignoreDup
                         }),
                         (err) => {

--- a/test/util.validateGeojson.test.js
+++ b/test/util.validateGeojson.test.js
@@ -148,3 +148,44 @@ tape('Assert fails according to schema ', (t) => {
 
     t.end();
 });
+
+tape('Duplicate ID Checks', (t) => {
+    let ids = new Set();
+
+    t.deepEquals(validateGeojson.validateFeature({
+        id: 1,
+        type: 'Feature',
+        action: 'modify',
+        properties: {
+            number: 0,
+            street: [{ 'display':'\\N','priority':0 }]
+        },
+        geometry: {
+            type: 'Point',
+            coordinates: [23.6,23.5]
+        }
+    }, {
+        ids: ids
+    }), []);
+
+    t.deepEquals(validateGeojson.validateFeature({
+        id: 1,
+        type: 'Feature',
+        action: 'modify',
+        properties: {
+            number: 0,
+            street: [{ 'display':'\\N','priority':0 }]
+        },
+        geometry: {
+            type: 'Point',
+            coordinates: [23.6,23.5]
+        }
+    }, {
+        ids: ids
+    }), [{
+        message: 'Feature ID: 1 exists more than once',
+        linenumber: 0
+    }]);
+
+    t.end();
+});

--- a/test/util.validateGeojson.test.js
+++ b/test/util.validateGeojson.test.js
@@ -9,7 +9,7 @@ const pipeline = require('stream').pipeline;
 const split = require('split');
 
 const ajv = new Ajv({
-        schemaId: 'auto'
+    schemaId: 'auto'
 });
 
 ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-04.json'));
@@ -150,7 +150,7 @@ tape('Assert fails according to schema ', (t) => {
 });
 
 tape('Duplicate ID Checks', (t) => {
-    let ids = new Set();
+    const ids = new Set();
 
     t.deepEquals(validateGeojson.validateFeature({
         id: 1,

--- a/util/validateGeojson.js
+++ b/util/validateGeojson.js
@@ -30,7 +30,7 @@ function validateGeojson(opts = {}) {
         schema = ajv.compile(opts.schema);
     }
 
-    let ids = opts.ids ? new Set() : false;
+    const ids = opts.ids ? new Set() : false;
 
     return transform(1, (feat, cb) => {
         if (!feat || !feat.trim()) return cb(null, '');

--- a/util/validateGeojson.js
+++ b/util/validateGeojson.js
@@ -79,13 +79,13 @@ function validateFeature(line, options) {
         feature = JSON.parse(line);
     }
 
-    if (feature.id && Set.has(feature.id)) {
+    if (feature.id && options.ids.has(feature.id)) {
         errors.push({
             message: `Feature ID: ${feature.id} exists more than once`,
             linenumber: options.linenumber
         });
     } else if (feature.id) {
-        options.ids.add(features.id);
+        options.ids.add(feature.id);
     }
 
     feature = rewind(feature);

--- a/util/validateGeojson.js
+++ b/util/validateGeojson.js
@@ -30,7 +30,7 @@ function validateGeojson(opts = {}) {
         schema = ajv.compile(opts.schema);
     }
 
-    const ids = opts.ids ? new Set() : false;
+    const ids = opts.ids === false ? false : new Set();
 
     return transform(1, (feat, cb) => {
         if (!feat || !feat.trim()) return cb(null, '');


### PR DESCRIPTION
Having a duplicate ID in a batch of features to import is a surefire way to have the import fail halfway through. This is a result of the `version` check that hecate applies, ensuring that two editors can't edit a given feature at the same time.

This adds a `Set` based id lookup to ensure that the validation module checks for duplicate IDs before an import is started. For large imports, it also exposes a flag to disable these checks.

cc/ @mapbox/search 