### PR TITLE
remove node-mb-string-size

### DIFF
--- a/lib/import.js
+++ b/lib/import.js
@@ -8,7 +8,6 @@ const fs = require('fs');
 const path = require('path');
 const split = require('split');
 const pipeline = require('stream').pipeline;
-const str_size = require('node-mb-string-size'); // eslint-disable-line node/no-missing-require
 const rewind = require('geojson-rewind');
 const prompt = require('prompt');
 const config = require('../package.json');
@@ -175,7 +174,7 @@ class Import {
                     line = String(line);
                     if (!line.trim()) continue;
 
-                    bytes += str_size(line);
+                    bytes += Buffer.from(line).length;
                     buffer.push(rewind(JSON.parse(line)));
 
                     if (bytes > MAX_UPLOAD) break;

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "minimist": "^1.2.0",
     "n-readlines": "^1.0.0 ",
     "nock": "^11.7.0",
-    "node-mb-string-size": "^1.0.3",
     "parallel-transform": "^1.2.0",
     "prompt": "^1.0.0",
     "request": "^2.88.0",


### PR DESCRIPTION
I cleaned and updated node-mb-string-size one last time in a patch just now, however I recommend dropping it. That lib solved an issue which is no longer present in modern NodeJS versions. It was deprecated, hence.

To be correct, NodeJS >= version 6 should work as expected, so if you do need to support anything before that, you should reject my PR