### PR TITLE
Parallel Reversion

### DIFF
--- a/lib/revert.js
+++ b/lib/revert.js
@@ -105,7 +105,6 @@ class Revert {
 
             try {
                 const db = await revert.cache(options, self.api);
-
                 revert.iterate(db, options.output);
 
                 revert.cleanCache(db);

--- a/test/lib.revert.test.js
+++ b/test/lib.revert.test.js
@@ -77,6 +77,7 @@ test('Clean revert of single delta', (t) => {
                 coordinates: [1, 1]
             }
         }]);
+
         t.end();
     });
 
@@ -385,4 +386,9 @@ test('Failed revert as feature has been edited since desired revert', (t) => {
         t.equals(err.message, 'Feature: 1 has been subsequenty edited. reversion not supported');
         t.end();
     });
+});
+
+test('Restore Nock', (t) => {
+        nock.cleanAll();
+        t.end();
 });

--- a/test/lib.revert.test.js
+++ b/test/lib.revert.test.js
@@ -389,6 +389,6 @@ test('Failed revert as feature has been edited since desired revert', (t) => {
 });
 
 test('Restore Nock', (t) => {
-        nock.cleanAll();
-        t.end();
+    nock.cleanAll();
+    t.end();
 });

--- a/util/revert.js
+++ b/util/revert.js
@@ -164,7 +164,7 @@ function cache(options, api) {
         deltai(options.start - 1);
 
         async function deltai(i) {
-            if (i <= options.end) {
+            if (i < options.end) {
                 i++;
             } else {
                 return resolve(db);

--- a/util/revert.js
+++ b/util/revert.js
@@ -161,9 +161,9 @@ function cache(options, api) {
                 VALUES (?, ?, ?);
         `);
 
-        delta(options.start - 1);
+        deltai(options.start - 1);
 
-        async function delta(i) {
+        async function deltai(i) {
             if (i <= options.end) {
                 i++;
             } else {
@@ -186,11 +186,13 @@ function cache(options, api) {
                         stmt.run(feat.id, feat.version, JSON.stringify(history));
                     } catch (err) {
                         if (err.message === 'UNIQUE constraint failed: features.id') {
-                            throw new Error(`Feature: ${feat.id} exists multiple times across deltas to revert. reversion not supported`);
+                            return done(new Error(`Feature: ${feat.id} exists multiple times across deltas to revert. reversion not supported`));
                         } else {
-                            throw err;
+                            return done(err);
                         }
                     }
+
+                    return done();
                 }, feat);
             }
 
@@ -198,7 +200,7 @@ function cache(options, api) {
                 if (err) return reject(err);
 
                 process.nextTick(() => {
-                    delta(i);
+                    deltai(i);
                 });
             });
         }

--- a/util/revert.js
+++ b/util/revert.js
@@ -2,6 +2,7 @@
 
 const { promisify } = require('util');
 const Sqlite = require('better-sqlite3');
+const Q = require('d3-queue').queue;
 const path = require('path');
 const os = require('os');
 const fs = require('fs');
@@ -148,42 +149,60 @@ function iterate(db, stream) {
  *
  * @returns {Promise}
  */
-async function cache(options, api) {
-    const db = createCache();
+function cache(options, api) {
+    return new Promise((resolve, reject) => {
+        const db = createCache();
 
-    const getDelta = promisify(api.getDelta);
-    const getFeatureHistory = promisify(api.getFeatureHistory);
+        const getDelta = promisify(api.getDelta);
+        const getFeatureHistory = promisify(api.getFeatureHistory);
 
-    const stmt = db.prepare(`
-        INSERT INTO features (id, version, history)
-            VALUES (?, ?, ?);
-    `);
+        const stmt = db.prepare(`
+            INSERT INTO features (id, version, history)
+                VALUES (?, ?, ?);
+        `);
 
-    for (let i = options.start; i <= options.end; i++) {
-        const delta = await getDelta({
-            delta: i
-        });
+        delta(options.start - 1);
 
-        for (const feat of delta.features.features) {
-            const history = await getFeatureHistory({
-                feature: feat.id
-            });
-
-            try {
-                stmt.run(feat.id, feat.version, JSON.stringify(history));
-            } catch (err) {
-                if (err.message === 'UNIQUE constraint failed: features.id') {
-                    throw new Error(`Feature: ${feat.id} exists multiple times across deltas to revert. reversion not supported`);
-                } else {
-                    throw err;
-                }
+        async function delta(i) {
+            if (i <= options.end) {
+                i++;
+            } else {
+                return resolve(db);
             }
 
+            const delta = await getDelta({
+                delta: i
+            });
+
+            const q = new Q(50);
+
+            for (const feat of delta.features.features) {
+                q.defer(async (feat, done) => {
+                    const history = await getFeatureHistory({
+                        feature: feat.id
+                    });
+
+                    try {
+                        stmt.run(feat.id, feat.version, JSON.stringify(history));
+                    } catch (err) {
+                        if (err.message === 'UNIQUE constraint failed: features.id') {
+                            throw new Error(`Feature: ${feat.id} exists multiple times across deltas to revert. reversion not supported`);
+                        } else {
+                            throw err;
+                        }
+                    }
+                }, feat);
+            }
+
+            q.awaitAll((err) => {
+                if (err) return reject(err);
+
+                process.nextTick(() => {
+                    delta(i);
+                });
+            });
         }
-    }
-
-    return db;
-
+    });
 }
 
 /**


### PR DESCRIPTION
## Context

This PR speeds up delta based reversions by running feature history retrieval in parallel

## Benchmarks

We tested on reverting an internal set of deltas (`107530 -> 107531`) and timing the results.

```
Master: 14m57.829s
Branch: 1m57.747s
```

cc/ @mapbox/search 