### PR TITLE
Simplify Auth

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,40 @@
+{
+    "rules": {
+        "block-scoped-var": 2,
+            "comma-dangle": [2, "only-multiline"],
+            "comma-style": 2,
+            "indent": 2,
+            "keyword-spacing": 2,
+            "no-console": 0,
+            "no-constant-condition": 0,
+            "no-else-return": 0,
+            "no-extra-parens": [2, "functions"],
+            "no-lonely-if": 2,
+            "no-new": 2,
+            "no-proto": 2,
+            "no-unused-vars": [2,{"args": "none"}],
+            "no-use-before-define": [2,"nofunc"],
+            "no-useless-escape": 0,
+            "space-before-blocks": 2,
+            "space-before-function-paren": [2, "never"],
+            "space-in-parens": 2,
+            "require-jsdoc": ["error", {
+                "require": {
+                    "FunctionExpression": true,
+                    "ClassDeclaration": true,
+                    "MethodDefinition": true
+                }
+            }],
+            "valid-jsdoc": ["error", {
+                "requireReturn": false,
+                "requireParamDescription": true,
+                "requireParamType": true
+            }]
+    },
+    "env": {
+        "node": "true",
+        "es6": "true"
+    },
+    "extends": ["@mapbox/eslint-config-geocoding"]
+}
+

--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ yarn global add '@mapbox/hecatejs'
 
 <h3 align=center>Instantiation</h3>
 
-<details>
-
 Note: if the username & password is not explicitly set, Hecate will fallback to checking for
 a `HECATE_USERNAME` & `HECATE_PASSWORD` environment variable. For the `url` parameter, be sure to include the protocol and (if necessary) port number.
 
@@ -53,8 +51,6 @@ The --url option must be provided for every subcommand but is omitted in this gu
 # Connecting to a local hecate server
 ./cli.js --url 'http://localhost:8000'
 ```
-
-</details>
 
 <h2 align=center>API Documentation</h2>
 

--- a/cli.js
+++ b/cli.js
@@ -18,7 +18,7 @@ class Hecate {
      * @param {Object} api.auth_rules [optional] If used as a library, an object containing the
      *                              authentication rules of the instance as retrieved from
      *                              /api/auth
-     *                              The CLI will automaticall attempt to populate this value
+     *                              The CLI will automatically attempt to populate this value
      */
     constructor(api = {}) {
         this.url = api.url ? new URL(api.url).toString() : 'http://localhost:8000';
@@ -184,7 +184,7 @@ if (require.main === module) {
         }
 
         /**
-         * Once Hecate instance is instatiated, run the requested command
+         * Once Hecate instance is instantiated, run the requested command
          *
          * @private
          * @returns {undefined}

--- a/cli.js
+++ b/cli.js
@@ -10,6 +10,16 @@ const settings = require('./package.json');
  * @class Hecate
  */
 class Hecate {
+    /**
+     * @param {Object} api Global API Settings Object
+     * @param {string} api.url URL of Hecate instance to interact with
+     * @param {string} api.username Hecate Username
+     * @param {string} api.password Hecate Password
+     * @param {Object} api.auth_rules [optional] If used as a library, an object containing the
+     *                              authentication rules of the instance as retrieved from
+     *                              /api/auth
+     *                              The CLI will automaticall attempt to populate this value
+     */
     constructor(api = {}) {
         this.url = api.url ? new URL(api.url).toString() : 'http://localhost:8000';
         this.user = false;
@@ -173,6 +183,12 @@ if (require.main === module) {
             return run();
         }
 
+        /**
+         * Once Hecate instance is instatiated, run the requested command
+         *
+         * @private
+         * @returns {undefined}
+         */
         function run() {
             if (!subcommand) {
                 hecate[command](argv);

--- a/docs/api.md
+++ b/docs/api.md
@@ -11,884 +11,666 @@
     -   [help][7]
     -   [get][8]
         -   [Parameters][9]
--   [validateBbox][10]
-    -   [Parameters][11]
--   [EOT][12]
-    -   [Parameters][13]
-    -   [\_transform][14]
+-   [Bounds][10]
+    -   [help][11]
+    -   [stats][12]
+        -   [Parameters][13]
+    -   [list][14]
         -   [Parameters][15]
-    -   [\_final][16]
+    -   [get][16]
         -   [Parameters][17]
--   [Bounds][18]
-    -   [help][19]
-    -   [stats][20]
+    -   [meta][18]
+        -   [Parameters][19]
+    -   [delete][20]
         -   [Parameters][21]
-    -   [list][22]
+    -   [set][22]
         -   [Parameters][23]
-    -   [get][24]
-        -   [Parameters][25]
-    -   [meta][26]
+-   [Clone][24]
+    -   [help][25]
+    -   [get][26]
         -   [Parameters][27]
-    -   [delete][28]
-        -   [Parameters][29]
-    -   [set][30]
+-   [Deltas][28]
+    -   [help][29]
+    -   [list][30]
         -   [Parameters][31]
--   [Clone][32]
-    -   [help][33]
-    -   [get][34]
-        -   [Parameters][35]
--   [Deltas][36]
-    -   [help][37]
-    -   [list][38]
+    -   [get][32]
+        -   [Parameters][33]
+-   [Feature][34]
+    -   [help][35]
+    -   [history][36]
+        -   [Parameters][37]
+    -   [key][38]
         -   [Parameters][39]
     -   [get][40]
         -   [Parameters][41]
--   [Feature][42]
-    -   [help][43]
-    -   [history][44]
-        -   [Parameters][45]
-    -   [key][46]
-        -   [Parameters][47]
-    -   [get][48]
-        -   [Parameters][49]
--   [ArrayReader][50]
-    -   [Parameters][51]
-    -   [next][52]
--   [Import][53]
+-   [ArrayReader][42]
+    -   [Parameters][43]
+    -   [next][44]
+-   [Import][45]
+    -   [help][46]
+    -   [multi][47]
+        -   [Parameters][48]
+-   [Revert][49]
+    -   [help][50]
+    -   [deltas][51]
+        -   [Parameters][52]
+-   [Schema][53]
     -   [help][54]
-    -   [multi][55]
+    -   [get][55]
         -   [Parameters][56]
--   [validateGeojson][57]
-    -   [Parameters][58]
--   [validateFeature][59]
-    -   [Parameters][60]
--   [Revert][61]
-    -   [help][62]
-    -   [deltas][63]
-        -   [Parameters][64]
--   [inverse][65]
-    -   [Parameters][66]
--   [iterate][67]
-    -   [Parameters][68]
--   [cache][69]
-    -   [Parameters][70]
--   [deltai][71]
-    -   [Parameters][72]
--   [createCache][73]
--   [cleanCache][74]
-    -   [Parameters][75]
--   [Schema][76]
-    -   [help][77]
-    -   [get][78]
-        -   [Parameters][79]
--   [Server][80]
-    -   [help][81]
-    -   [get][82]
-        -   [Parameters][83]
-    -   [stats][84]
-        -   [Parameters][85]
--   [Tiles][86]
-    -   [help][87]
-    -   [get][88]
-        -   [Parameters][89]
--   [User][90]
-    -   [help][91]
-    -   [list][92]
-        -   [Parameters][93]
-    -   [info][94]
-        -   [Parameters][95]
-    -   [register][96]
-        -   [Parameters][97]
--   [Webhooks][98]
-    -   [help][99]
-    -   [list][100]
-        -   [Parameters][101]
-    -   [get][102]
-        -   [Parameters][103]
-    -   [delete][104]
-        -   [Parameters][105]
-    -   [update][106]
-        -   [Parameters][107]
-    -   [create][108]
-        -   [Parameters][109]
+-   [Server][57]
+    -   [help][58]
+    -   [get][59]
+        -   [Parameters][60]
+    -   [stats][61]
+        -   [Parameters][62]
+-   [Tiles][63]
+    -   [help][64]
+    -   [get][65]
+        -   [Parameters][66]
+-   [User][67]
+    -   [help][68]
+    -   [list][69]
+        -   [Parameters][70]
+    -   [info][71]
+        -   [Parameters][72]
+    -   [register][73]
+        -   [Parameters][74]
+-   [Webhooks][75]
+    -   [help][76]
+    -   [list][77]
+        -   [Parameters][78]
+    -   [get][79]
+        -   [Parameters][80]
+    -   [delete][81]
+        -   [Parameters][82]
+    -   [update][83]
+        -   [Parameters][84]
+    -   [create][85]
+        -   [Parameters][86]
 
 ## Hecate
 
-[cli.js:12-72][110]
+[cli.js:12-72][87]
 
 ## Auth
 
-[lib/auth.js:13-93][111]
+[lib/auth.js:13-93][88]
 
--   **See: [Hecate Documentation][112]**
+-   **See: [Hecate Documentation][89]**
 
 ### help
 
-[lib/auth.js:26-35][113]
+[lib/auth.js:26-35][90]
 
 Print help documentation about the subcommand to stderr
 
 ### get
 
-[lib/auth.js:43-92][114]
+[lib/auth.js:43-92][91]
 
 Return the auth settings for a given hecate instance
 
 #### Parameters
 
--   `options` **![Object][115]** Options for making a request to the auth API (optional, default `{}`)
--   `cb` **[function][116]** (err, res) style callback function
+-   `options` **![Object][92]** Options for making a request to the auth API (optional, default `{}`)
+-   `cb` **[function][93]** (err, res) style callback function
 
 ## BBox
 
-[lib/bbox.js:17-158][117]
+[lib/bbox.js:17-158][94]
 
--   **See: [Hecate Documentation][118]**
+-   **See: [Hecate Documentation][95]**
 
 ### help
 
-[lib/bbox.js:30-39][119]
+[lib/bbox.js:30-39][96]
 
 Print help documentation about the subcommand to stderr
 
 ### get
 
-[lib/bbox.js:55-157][120]
+[lib/bbox.js:55-157][97]
 
 Queries hecate /api/data/features endpoint
 Currently supports downloading features by bbox
 
 #### Parameters
 
--   `options` **![Object][115]** Options for making a request to the hecate /api/data/features endpoint (optional, default `{}`)
-    -   `options.history` **[boolean][121]?** [default: false] If true, return current and historic features
+-   `options` **![Object][92]** Options for making a request to the hecate /api/data/features endpoint (optional, default `{}`)
+    -   `options.history` **[boolean][98]?** [default: false] If true, return current and historic features
                                          within the given bbox.
-    -   `options.bbox` **([Array][122] \| [string][123])?** Bounding box of features to download from hecate
-    -   `options.output` **[Stream][124]?** Stream to write line-delimited GeoJSON to
--   `cb` **[function][116]** (err, res) style callback function
+    -   `options.bbox` **([Array][99] \| [string][100])?** Bounding box of features to download from hecate
+    -   `options.output` **[Stream][101]?** Stream to write line-delimited GeoJSON to
+-   `cb` **[function][93]** (err, res) style callback function
 
-Returns **[function][116]** (err, res) style callback
-
-## validateBbox
-
-[util/validateBbox.js:9-39][125]
-
-Accepts a bbox as a string or array, and validates (naive with regards to the Antimeridian)
-
-### Parameters
-
--   `bboxInput` **([Array][122] \| [string][123])** Array in the format [minX,minY,maxX,maxY] or string in the format minX,minY,maxX,maxY
-
-Returns **[string][123]** String in the format minX,minY,maxX,maxY
-
-## EOT
-
-[util/eot.js:12-64][126]
-
-**Extends Transform**
-
-Transform stream to passthrough linedelimited GeoJSON
-and upon termination of the stream, ensure EOT
-character was present to ensure all data was obtained
-
-### Parameters
-
--   `cb` **[function][116]** (err, res) style callback
-
-### \_transform
-
-[util/eot.js:39-50][127]
-
-Internal transform function to passthrough data
-and look for EOT character
-
-#### Parameters
-
--   `chunk` **[Buffer][128]** chunk to passthrough
--   `encoding` **[string][123]** The encoding of the chunk
--   `done` **[function][116]** completion callback
-
-Returns **[function][116]** callback function
-
-### \_final
-
-[util/eot.js:59-63][129]
-
-Ensure the stream completeled successfully, checking for the EOT character
-
-#### Parameters
-
--   `done` **[function][116]** completion callback
-
-Returns **[function][116]** (err, res) style callback
+Returns **[function][93]** (err, res) style callback
 
 ## Bounds
 
-[lib/bounds.js:16-629][130]
+[lib/bounds.js:16-629][102]
 
--   **See: [Hecate Documentation][131]**
+-   **See: [Hecate Documentation][103]**
 
 ### help
 
-[lib/bounds.js:29-43][132]
+[lib/bounds.js:29-43][104]
 
 Print help documentation about the subcommand to stderr
 
 ### stats
 
-[lib/bounds.js:53-139][133]
+[lib/bounds.js:53-139][105]
 
 Return stats of geo data within a give bounds
 
 #### Parameters
 
--   `options` **![Object][115]** options for makign a query to the bounds list endpoint (optional, default `{}`)
--   `cb` **[function][116]** (err, res) style callback function
+-   `options` **![Object][92]** options for makign a query to the bounds list endpoint (optional, default `{}`)
+-   `cb` **[function][93]** (err, res) style callback function
 
-Returns **[function][116]** (err, res) style callback
+Returns **[function][93]** (err, res) style callback
 
 ### list
 
-[lib/bounds.js:149-225][134]
+[lib/bounds.js:149-225][106]
 
 Return a list of the bounds that are currently loaded on the server
 
 #### Parameters
 
--   `options` **![Object][115]** options for makign a query to the bounds list endpoint (optional, default `{}`)
--   `cb` **[function][116]** (err, res) style callback function
+-   `options` **![Object][92]** options for makign a query to the bounds list endpoint (optional, default `{}`)
+-   `cb` **[function][93]** (err, res) style callback function
 
-Returns **[function][116]** (err, res) style callback
+Returns **[function][93]** (err, res) style callback
 
 ### get
 
-[lib/bounds.js:238-324][135]
+[lib/bounds.js:238-324][107]
 
 Queries the /api/data/bounds endpoints, returning a
 line-delimited stream of GeoJSON Features
 
 #### Parameters
 
--   `options` **![Object][115]** Options for making a request to the bounds endpoint (optional, default `{}`)
-    -   `options.bound` **[String][123]?** Name of the bound to download from
-    -   `options.output` **[Stream][124]?** Stream to write line-delimited GeoJSON to
--   `cb` **[function][116]** (err, res) style callback function
+-   `options` **![Object][92]** Options for making a request to the bounds endpoint (optional, default `{}`)
+    -   `options.bound` **[String][100]?** Name of the bound to download from
+    -   `options.output` **[Stream][101]?** Stream to write line-delimited GeoJSON to
+-   `cb` **[function][93]** (err, res) style callback function
 
-Returns **[function][116]** (err, res) style callback
+Returns **[function][93]** (err, res) style callback
 
 ### meta
 
-[lib/bounds.js:335-423][136]
+[lib/bounds.js:335-423][108]
 
 Returns underlying bounds geojson for a given bounds
 
 #### Parameters
 
--   `options` **![Object][115]** Options for making a request to the bounds endpoint (optional, default `{}`)
-    -   `options.bound` **[String][123]?** Name of the bound to download from
--   `cb` **[function][116]** (err, res) style callback function
+-   `options` **![Object][92]** Options for making a request to the bounds endpoint (optional, default `{}`)
+    -   `options.bound` **[String][100]?** Name of the bound to download from
+-   `cb` **[function][93]** (err, res) style callback function
 
-Returns **[function][116]** (err, res) style callback
+Returns **[function][93]** (err, res) style callback
 
 ### delete
 
-[lib/bounds.js:434-518][137]
+[lib/bounds.js:434-518][109]
 
 Delete a boundary file
 
 #### Parameters
 
--   `options` **![Object][115]** Options for making a request to the bounds endpoint (optional, default `{}`)
-    -   `options.bound` **[String][123]?** Name of the bound to download from
--   `cb` **[function][116]** (err, res) style callback function
+-   `options` **![Object][92]** Options for making a request to the bounds endpoint (optional, default `{}`)
+    -   `options.bound` **[String][100]?** Name of the bound to download from
+-   `cb` **[function][93]** (err, res) style callback function
 
-Returns **[function][116]** (err, res) style callback
+Returns **[function][93]** (err, res) style callback
 
 ### set
 
-[lib/bounds.js:530-628][138]
+[lib/bounds.js:530-628][110]
 
 Create or update a boundary file
 
 #### Parameters
 
--   `options` **![Object][115]** Options for making a request to the bounds endpoint (optional, default `{}`)
-    -   `options.bound` **[String][123]?** Name of the bound to download from
-    -   `options.geom` **[String][123]?** JSON Geometry of bound
--   `cb` **[function][116]** (err, res) style callback function
+-   `options` **![Object][92]** Options for making a request to the bounds endpoint (optional, default `{}`)
+    -   `options.bound` **[String][100]?** Name of the bound to download from
+    -   `options.geom` **[String][100]?** JSON Geometry of bound
+-   `cb` **[function][93]** (err, res) style callback function
 
-Returns **[function][116]** (err, res) style callback
+Returns **[function][93]** (err, res) style callback
 
 ## Clone
 
-[lib/clone.js:16-126][139]
+[lib/clone.js:16-126][111]
 
--   **See: [Hecate Documentation][140]**
+-   **See: [Hecate Documentation][112]**
 
 ### help
 
-[lib/clone.js:29-38][141]
+[lib/clone.js:29-38][113]
 
 Print help documentation about the subcommand to stderr
 
 ### get
 
-[lib/clone.js:49-125][142]
+[lib/clone.js:49-125][114]
 
 Clone all data on a given hecate server
 
 #### Parameters
 
--   `options` **![Object][115]** Options for making a request to the hecate /api/data/features endpoint (optional, default `{}`)
-    -   `options.output` **[Stream][124]?** Stream to write line-delimited GeoJSON to
--   `cb` **[function][116]** (err, res) style callback function
+-   `options` **![Object][92]** Options for making a request to the hecate /api/data/features endpoint (optional, default `{}`)
+    -   `options.output` **[Stream][101]?** Stream to write line-delimited GeoJSON to
+-   `cb` **[function][93]** (err, res) style callback function
 
-Returns **[function][116]** (err, res) style callback
+Returns **[function][93]** (err, res) style callback
 
 ## Deltas
 
-[lib/deltas.js:15-242][143]
+[lib/deltas.js:15-242][115]
 
--   **See: [Hecate Documentation][144]**
+-   **See: [Hecate Documentation][116]**
 
 ### help
 
-[lib/deltas.js:28-37][145]
+[lib/deltas.js:28-37][117]
 
 Print help documentation about the subcommand to stderr
 
 ### list
 
-[lib/deltas.js:49-145][146]
+[lib/deltas.js:49-145][118]
 
 Queries the recent deltas list, returning the most recent 100 deltas
 
 #### Parameters
 
--   `options` **![Object][115]** Options for making a request to the deltas endpoint (optional, default `{}`)
-    -   `options.limit` **[String][123]** Number of deltas to list by default (optional, default `100`)
-    -   `options.offset` **[String][123]?** delta id to start listing at
--   `cb` **[function][116]** (err, res) style callback function
+-   `options` **![Object][92]** Options for making a request to the deltas endpoint (optional, default `{}`)
+    -   `options.limit` **[String][100]** Number of deltas to list by default (optional, default `100`)
+    -   `options.offset` **[String][100]?** delta id to start listing at
+-   `cb` **[function][93]** (err, res) style callback function
 
-Returns **[function][116]** (err, res) style callback
+Returns **[function][93]** (err, res) style callback
 
 ### get
 
-[lib/deltas.js:155-241][147]
+[lib/deltas.js:155-241][119]
 
 Returns data about a specific delta
 
 #### Parameters
 
--   `options` **![Object][115]** Options for making a request to the deltas endpoint (optional, default `{}`)
--   `cb` **[function][116]** (err, res) style callback function
+-   `options` **![Object][92]** Options for making a request to the deltas endpoint (optional, default `{}`)
+-   `cb` **[function][93]** (err, res) style callback function
 
-Returns **[function][116]** (err, res) style callback
+Returns **[function][93]** (err, res) style callback
 
 ## Feature
 
-[lib/feature.js:15-333][148]
+[lib/feature.js:15-333][120]
 
--   **See: [Hecate Documentation][149]**
+-   **See: [Hecate Documentation][121]**
 
 ### help
 
-[lib/feature.js:28-38][150]
+[lib/feature.js:28-38][122]
 
 Print help documentation about the subcommand to stderr
 
 ### history
 
-[lib/feature.js:50-136][151]
+[lib/feature.js:50-136][123]
 
 Queries the feature store endpoint, returning a history of a
 GeoJSON Feature
 
 #### Parameters
 
--   `options` **![Object][115]** Options for making a request to the bounds endpoint (optional, default `{}`)
-    -   `options.feature` **[String][123]?** ID of the feature to download from
--   `cb` **[function][116]** (err, res) style callback function
+-   `options` **![Object][92]** Options for making a request to the bounds endpoint (optional, default `{}`)
+    -   `options.feature` **[String][100]?** ID of the feature to download from
+-   `cb` **[function][93]** (err, res) style callback function
 
-Returns **[function][116]** (err, res) style callback
+Returns **[function][93]** (err, res) style callback
 
 ### key
 
-[lib/feature.js:148-234][152]
+[lib/feature.js:148-234][124]
 
 Queries the feature store endpoint by key, returning a
 GeoJSON Feature
 
 #### Parameters
 
--   `options` **![Object][115]** Options for making a request to the bounds endpoint (optional, default `{}`)
-    -   `options.feature` **[String][123]?** key of the feature to download from
--   `cb` **[function][116]** (err, res) style callback function
+-   `options` **![Object][92]** Options for making a request to the bounds endpoint (optional, default `{}`)
+    -   `options.feature` **[String][100]?** key of the feature to download from
+-   `cb` **[function][93]** (err, res) style callback function
 
-Returns **[function][116]** (err, res) style callback
+Returns **[function][93]** (err, res) style callback
 
 ### get
 
-[lib/feature.js:246-332][153]
+[lib/feature.js:246-332][125]
 
 Queries the feature store endpoint, returning a
 GeoJSON Feature
 
 #### Parameters
 
--   `options` **![Object][115]** Options for making a request to the bounds endpoint (optional, default `{}`)
-    -   `options.feature` **[String][123]?** ID of the feature to download from
--   `cb` **[function][116]** (err, res) style callback function
+-   `options` **![Object][92]** Options for making a request to the bounds endpoint (optional, default `{}`)
+    -   `options.feature` **[String][100]?** ID of the feature to download from
+-   `cb` **[function][93]** (err, res) style callback function
 
-Returns **[function][116]** (err, res) style callback
+Returns **[function][93]** (err, res) style callback
 
 ## ArrayReader
 
-[lib/import.js:26-52][154]
+[lib/import.js:26-52][126]
 
 Allow features to be passed to the import API as an array
 instead of as a stream
 
 ### Parameters
 
--   `array` **[Array][122]&lt;[Object][115]>** Array of features
+-   `array` **[Array][99]&lt;[Object][92]>** Array of features
 
 ### next
 
-[lib/import.js:42-51][155]
+[lib/import.js:42-51][127]
 
 Return the next feature in the array, mimics a stream
 
-Returns **[string][123]** GeoJSON Feature to import
+Returns **[string][100]** GeoJSON Feature to import
 
 ## Import
 
-[lib/import.js:60-307][156]
+[lib/import.js:60-307][128]
 
--   **See: [Hecate Documentation][157]**
+-   **See: [Hecate Documentation][129]**
 
 ### help
 
-[lib/import.js:73-86][158]
+[lib/import.js:73-86][130]
 
 Print help documentation about the subcommand to stderr
 
 ### multi
 
-[lib/import.js:102-306][159]
+[lib/import.js:102-306][131]
 
 Given a Stream of line-delimited features or an Array of features, validate and
 import them
 
 #### Parameters
 
--   `options` **[Object][115]** options object (optional, default `{}`)
-    -   `options.message` **[string][123]** Human readable description of changes
-    -   `options.input` **([string][123] \| [Array][122]&lt;[Object][115]>)** String of filepath or Array containing features to import
-    -   `options.ignoreRHR` **[boolean][121]** Ignore RHR winding errors
-    -   `options.ignoreDup` **[boolean][121]** Don't check duplicate IDs (will usually cause an import failure if they exist)
-    -   `options.dryrun` **[boolean][121]** Perform all validation but don't import
--   `cb` **[function][116]** (err, res) style callback
+-   `options` **[Object][92]** options object (optional, default `{}`)
+    -   `options.message` **[string][100]** Human readable description of changes
+    -   `options.input` **([string][100] \| [Array][99]&lt;[Object][92]>)** String of filepath or Array containing features to import
+    -   `options.ignoreRHR` **[boolean][98]** Ignore RHR winding errors
+    -   `options.ignoreDup` **[boolean][98]** Don't check duplicate IDs (will usually cause an import failure if they exist)
+    -   `options.dryrun` **[boolean][98]** Perform all validation but don't import
+-   `cb` **[function][93]** (err, res) style callback
 
-Returns **[function][116]** (err, res) style callback
-
-## validateGeojson
-
-[util/validateGeojson.js:25-59][160]
-
-Ensure geometries are valid before import
-
-### Parameters
-
--   `opts` **[Object][115]** Options object (optional, default `{}`)
-    -   `opts.ignoreRHR` **[boolean][121]** =false Ignore Right Hand Rule errors
-    -   `opts.schema` **[Object][115]** JSON Schema to validate properties against
-    -   `opts.ids` **[boolean][121]** If false, disable duplicate ID checking
-
-Returns **[Stream][124]** transform stream to validate GeoJSON
-
-## validateFeature
-
-[util/validateGeojson.js:73-215][161]
-
-Validate a single feature
-
-### Parameters
-
--   `line` **([Object][115] \| [string][123])** Feature to validate
--   `options` **[Object][115]** Validation Options
-    -   `options.ignoreRHR` **[boolean][121]** Ignore winding order
-    -   `options.schema` **[Function][116]** AJV Function to validate feature properties against a JSON Schema
-    -   `options.linenumber` **[number][162]** Linenumber to output in error object
-    -   `options.ids` **[Set][163]** Set to keep track of feature id duplicates
-
-Returns **[Array][122]** Array of errors (empty array if none)
+Returns **[function][93]** (err, res) style callback
 
 ## Revert
 
-[lib/revert.js:10-157][164]
+[lib/revert.js:10-157][132]
 
 ### help
 
-[lib/revert.js:23-34][165]
+[lib/revert.js:23-34][133]
 
 Print help documentation about the subcommand to stderr
 
 ### deltas
 
-[lib/revert.js:48-156][166]
+[lib/revert.js:48-156][134]
 
 Revert a given set of deltas
 
 #### Parameters
 
--   `options` **![Object][115]** Options for making reversion of a set of deltas (optional, default `{}`)
-    -   `options.start` **[number][162]** Inclusive start delta ID to revert
-    -   `options.end` **[number][162]** Inclusive end delta ID to revert
-    -   `options.output` **[Stream][124]?** Stream to write line-delimited GeoJSON to
--   `cb` **[function][116]** (err, res) style callback function
+-   `options` **![Object][92]** Options for making reversion of a set of deltas (optional, default `{}`)
+    -   `options.start` **[number][135]** Inclusive start delta ID to revert
+    -   `options.end` **[number][135]** Inclusive end delta ID to revert
+    -   `options.output` **[Stream][101]?** Stream to write line-delimited GeoJSON to
+-   `cb` **[function][93]** (err, res) style callback function
 
-Returns **[function][116]** (err, res) style callback
-
-## inverse
-
-[util/revert.js:50-111][167]
-
-Given the feature history for a single feature and the version of the feature
-to be reverted, calculate a feature that can be uploaded which will
-restore the state of the feature to that of the version preceding
-the version supplied
-
-Example:
-
-User wants to revert/rollback the changes made in v4 to be those in v3
-
-Current State:
-Feature: 123
-[ v1, v2, v3, v4 ]
-
-End State:
-Feature:123
-[ v1, v2, v3, v4, v5 ]
-
-Where v5 is the calculated inverse operation of v4
-
-Inverses:
-
-Below is the table of inverses, the action that must be applied
-to "undo" a given feature action
-
-| Initial Action | Inverse |
-| -------------- | ------- |
-| Create         | Delete  |
-| Modify         | Modify  |
-| Delete         | Restore |
-| Restore        | Delete  |
-
-See the Hecate docs for more information about feature actions
-and versioning
-
-### Parameters
-
--   `history` **[Array][122]&lt;[Object][115]>** Array of features accross all verisons of the feature
--   `version` **[number][162]** feature version that should be rolled back
-
-Returns **[Object][115]** Returns calculated inverse feature
-
-## iterate
-
-[util/revert.js:121-139][168]
-
-Iterate over Sqlite3 database containing features to revert to previous state
-
-Writes inversion to given writable stream
-
-### Parameters
-
--   `db` **[Object][115]** sqlite3 db to iterate over
--   `stream` **[Stream][124]** output stream to write inverted features to
-
-## cache
-
-[util/revert.js:154-219][169]
-
-Given a start/end range for a set of deltas, download
-each of the deltas, then iterate through each feature,
-retreiving it's history and writing it to disk
-
-### Parameters
-
--   `options` **[Object][115]** options object
-    -   `options.start` **[number][162]** Delta Start ID
-    -   `options.end` **[number][162]** Delta End ID
--   `api` **[Hecate][170]** Hecate Instance for API calls
-
-Returns **[Promise][171]** Promise containing db instance or error
-
-## deltai
-
-[util/revert.js:177-217][172]
-
-Retrieve a single delta at a time, and then
-each of it's component feature histories in parallem
-commiting each to the database
-
-### Parameters
-
--   `i` **[number][162]** delta ID last retrieved
-
-Returns **[undefined][173]** 
-
-## createCache
-
-[util/revert.js:227-239][174]
-
-Create a new reversion sqlite3 database, initialize it with table
-definitions, and pass back db object to caller
-
-Returns **[Object][115]** Sqlite3 Database Handler
-
-## cleanCache
-
-[util/revert.js:248-254][175]
-
-Given a sqlite instance, close and delete it
-
-### Parameters
-
--   `db` **[Object][115]** sqlite3 database instance
-
-Returns **[undefined][173]** 
+Returns **[function][93]** (err, res) style callback
 
 ## Schema
 
-[lib/schema.js:15-127][176]
+[lib/schema.js:15-127][136]
 
--   **See: [Hecate Documentation][177]**
+-   **See: [Hecate Documentation][137]**
 
 ### help
 
-[lib/schema.js:28-37][178]
+[lib/schema.js:28-37][138]
 
 Print help documentation about the subcommand to stderr
 
 ### get
 
-[lib/schema.js:47-126][179]
+[lib/schema.js:47-126][139]
 
 Retrieve a JSON schema that feature properties must conform to
 
 #### Parameters
 
--   `options` **[Object][115]** options object (optional, default `{}`)
--   `cb` **[function][116]** (err, res) style callback
+-   `options` **[Object][92]** options object (optional, default `{}`)
+-   `cb` **[function][93]** (err, res) style callback
 
-Returns **[function][116]** (err, res) style callback
+Returns **[function][93]** (err, res) style callback
 
 ## Server
 
-[lib/server.js:15-209][180]
+[lib/server.js:15-209][140]
 
--   **See: [Hecate Documentation][181]**
+-   **See: [Hecate Documentation][141]**
 
 ### help
 
-[lib/server.js:28-38][182]
+[lib/server.js:28-38][142]
 
 Print help documentation about the subcommand to stderr
 
 ### get
 
-[lib/server.js:49-123][183]
+[lib/server.js:49-123][143]
 
 Get server metadata
 
 #### Parameters
 
--   `options` **![Object][115]** Options for making a request to meta API (optional, default `{}`)
--   `cb` **[function][116]** (err, res) style callback function
+-   `options` **![Object][92]** Options for making a request to meta API (optional, default `{}`)
+-   `cb` **[function][93]** (err, res) style callback function
 
-Returns **[function][116]** (err, res) style callback
+Returns **[function][93]** (err, res) style callback
 
 ### stats
 
-[lib/server.js:134-208][184]
+[lib/server.js:134-208][144]
 
 Get server stats
 
 #### Parameters
 
--   `options` **![Object][115]** Options for making a request to meta API (optional, default `{}`)
--   `cb` **[function][116]** (err, res) style callback function
+-   `options` **![Object][92]** Options for making a request to meta API (optional, default `{}`)
+-   `cb` **[function][93]** (err, res) style callback function
 
-Returns **[function][116]** (err, res) style callback
+Returns **[function][93]** (err, res) style callback
 
 ## Tiles
 
-[lib/tiles.js:15-134][185]
+[lib/tiles.js:15-134][145]
 
--   **See: [Hecate Documentation][186]**
+-   **See: [Hecate Documentation][146]**
 
 ### help
 
-[lib/tiles.js:28-36][187]
+[lib/tiles.js:28-36][147]
 
 Print help documentation about the subcommand to stderr
 
 ### get
 
-[lib/tiles.js:48-133][188]
+[lib/tiles.js:48-133][148]
 
 Fetch a Mapbox Vector Tile for the given zxy
 
 #### Parameters
 
--   `options` **![Object][115]** Options for making a request to the deltas endpoint (optional, default `{}`)
-    -   `options.zxy` **[String][123]?** z/x/y coordinate to request
--   `cb` **[function][116]** (err, res) style callback function
+-   `options` **![Object][92]** Options for making a request to the deltas endpoint (optional, default `{}`)
+    -   `options.zxy` **[String][100]?** z/x/y coordinate to request
+-   `cb` **[function][93]** (err, res) style callback function
 
-Returns **[function][116]** (err, res) style callback
+Returns **[function][93]** (err, res) style callback
 
 ## User
 
-[lib/user.js:15-332][189]
+[lib/user.js:15-332][149]
 
--   **See: [Hecate Documentation][190]**
+-   **See: [Hecate Documentation][150]**
 
 ### help
 
-[lib/user.js:28-39][191]
+[lib/user.js:28-39][151]
 
 Print help documentation about the subcommand to stderr
 
 ### list
 
-[lib/user.js:50-133][192]
+[lib/user.js:50-133][152]
 
 List users with optional filtering
 
 #### Parameters
 
--   `options` **[Object][115]** Options object (optional, default `{}`)
-    -   `options.filter` **[string][123]** User prefix to filter by
--   `cb` **[function][116]** (err, res) style callback
+-   `options` **[Object][92]** Options object (optional, default `{}`)
+    -   `options.filter` **[string][100]** User prefix to filter by
+-   `cb` **[function][93]** (err, res) style callback
 
-Returns **[function][116]** (err, res) style callback
+Returns **[function][93]** (err, res) style callback
 
 ### info
 
-[lib/user.js:143-216][193]
+[lib/user.js:143-216][153]
 
 Retrieve metadata about the user that makes the request
 
 #### Parameters
 
--   `options` **[Object][115]** options object (optional, default `{}`)
--   `cb` **[function][116]** (err, res) style callback
+-   `options` **[Object][92]** options object (optional, default `{}`)
+-   `cb` **[function][93]** (err, res) style callback
 
-Returns **[function][116]** (err, res) style callback
+Returns **[function][93]** (err, res) style callback
 
 ### register
 
-[lib/user.js:229-331][194]
+[lib/user.js:229-331][154]
 
 Register a new user account
 
 #### Parameters
 
--   `options` **[Object][115]** options object (optional, default `{}`)
-    -   `options.username` **[string][123]** Username to register
-    -   `options.email` **[string][123]** Email of account to register
-    -   `options.password` **[string][123]** Password of account to register
--   `cb` **[function][116]** (err, res) style callback
+-   `options` **[Object][92]** options object (optional, default `{}`)
+    -   `options.username` **[string][100]** Username to register
+    -   `options.email` **[string][100]** Email of account to register
+    -   `options.password` **[string][100]** Password of account to register
+-   `cb` **[function][93]** (err, res) style callback
 
-Returns **[function][116]** (err, res) style callback
+Returns **[function][93]** (err, res) style callback
 
 ## Webhooks
 
-[lib/webhooks.js:15-575][195]
+[lib/webhooks.js:15-575][155]
 
--   **See: [Hecate Documentation][196]**
+-   **See: [Hecate Documentation][156]**
 
 ### help
 
-[lib/webhooks.js:28-41][197]
+[lib/webhooks.js:28-41][157]
 
 Print help documentation about the subcommand to stderr
 
 ### list
 
-[lib/webhooks.js:52-128][198]
+[lib/webhooks.js:52-128][158]
 
 Queries hecate /api/webhooks endpoint
 
 #### Parameters
 
--   `options` **![Object][115]** Options for making a request to the hecate /api/webhooks endpoint (optional, default `{}`)
--   `cb` **[function][116]** (err, res) style callback function
+-   `options` **![Object][92]** Options for making a request to the hecate /api/webhooks endpoint (optional, default `{}`)
+-   `cb` **[function][93]** (err, res) style callback function
 
-Returns **[function][116]** (err, res) style callback
+Returns **[function][93]** (err, res) style callback
 
 ### get
 
-[lib/webhooks.js:140-226][199]
+[lib/webhooks.js:140-226][159]
 
 Get a specific webhook given the ID
 
 #### Parameters
 
--   `options` **![Object][115]** Options for making a request to the hecate /api/webhooks endpoint (optional, default `{}`)
-    -   `options.id` **[number][162]** ID of the webhook to retreive
--   `cb` **[function][116]** (err, res) style callback function
+-   `options` **![Object][92]** Options for making a request to the hecate /api/webhooks endpoint (optional, default `{}`)
+    -   `options.id` **[number][135]** ID of the webhook to retreive
+-   `cb` **[function][93]** (err, res) style callback function
 
-Returns **[function][116]** (err, res) style callback function
+Returns **[function][93]** (err, res) style callback function
 
 ### delete
 
-[lib/webhooks.js:238-323][200]
+[lib/webhooks.js:238-323][160]
 
 Delete a specific webhook given the ID
 
 #### Parameters
 
--   `options` **![Object][115]** Options for making a request to the hecate /api/webhooks endpoint (optional, default `{}`)
-    -   `options.id` **[number][162]** ID of the webhook to delete
--   `cb` **[function][116]** (err, res) style callback function
+-   `options` **![Object][92]** Options for making a request to the hecate /api/webhooks endpoint (optional, default `{}`)
+    -   `options.id` **[number][135]** ID of the webhook to delete
+-   `cb` **[function][93]** (err, res) style callback function
 
-Returns **[function][116]** (err, res) style callback function
+Returns **[function][93]** (err, res) style callback function
 
 ### update
 
-[lib/webhooks.js:338-453][201]
+[lib/webhooks.js:338-453][161]
 
 Update a given webhook ID
 
 #### Parameters
 
--   `options` **![Object][115]** Options for making a request to the hecate /api/webhooks endpoint (optional, default `{}`)
-    -   `options.id` **[number][162]** ID of the webhook to update
-    -   `options.name` **[string][123]** Name of the webhook
-    -   `options.url` **[string][123]** URL of the webhook
-    -   `options.actions` **[Array][122]&lt;[string][123]>** server actions the webhook should be fired on
--   `cb` **[function][116]** (err, res) style callback function
+-   `options` **![Object][92]** Options for making a request to the hecate /api/webhooks endpoint (optional, default `{}`)
+    -   `options.id` **[number][135]** ID of the webhook to update
+    -   `options.name` **[string][100]** Name of the webhook
+    -   `options.url` **[string][100]** URL of the webhook
+    -   `options.actions` **[Array][99]&lt;[string][100]>** server actions the webhook should be fired on
+-   `cb` **[function][93]** (err, res) style callback function
 
-Returns **[function][116]** (err, res) style callback function
+Returns **[function][93]** (err, res) style callback function
 
 ### create
 
-[lib/webhooks.js:467-574][202]
+[lib/webhooks.js:467-574][162]
 
 Create a new webhook
 
 #### Parameters
 
--   `options` **![Object][115]** Options for making a request to the hecate /api/webhooks endpoint (optional, default `{}`)
-    -   `options.name` **[string][123]** Name of the webhook
-    -   `options.url` **[string][123]** URL of the webhook
-    -   `options.actions` **[Array][122]&lt;[string][123]>** server actions the webhook should be fired on
--   `cb` **[function][116]** (err, res) style callback function
+-   `options` **![Object][92]** Options for making a request to the hecate /api/webhooks endpoint (optional, default `{}`)
+    -   `options.name` **[string][100]** Name of the webhook
+    -   `options.url` **[string][100]** URL of the webhook
+    -   `options.actions` **[Array][99]&lt;[string][100]>** server actions the webhook should be fired on
+-   `cb` **[function][93]** (err, res) style callback function
 
-Returns **[function][116]** (err, res) style callback function
+Returns **[function][93]** (err, res) style callback function
 
 [1]: #hecate
 
@@ -908,388 +690,308 @@ Returns **[function][116]** (err, res) style callback function
 
 [9]: #parameters-1
 
-[10]: #validatebbox
+[10]: #bounds
 
-[11]: #parameters-2
+[11]: #help-2
 
-[12]: #eot
+[12]: #stats
 
-[13]: #parameters-3
+[13]: #parameters-2
 
-[14]: #_transform
+[14]: #list
 
-[15]: #parameters-4
+[15]: #parameters-3
 
-[16]: #_final
+[16]: #get-2
 
-[17]: #parameters-5
+[17]: #parameters-4
 
-[18]: #bounds
+[18]: #meta
 
-[19]: #help-2
+[19]: #parameters-5
 
-[20]: #stats
+[20]: #delete
 
 [21]: #parameters-6
 
-[22]: #list
+[22]: #set
 
 [23]: #parameters-7
 
-[24]: #get-2
+[24]: #clone
 
-[25]: #parameters-8
+[25]: #help-3
 
-[26]: #meta
+[26]: #get-3
 
-[27]: #parameters-9
+[27]: #parameters-8
 
-[28]: #delete
+[28]: #deltas
 
-[29]: #parameters-10
+[29]: #help-4
 
-[30]: #set
+[30]: #list-1
 
-[31]: #parameters-11
+[31]: #parameters-9
 
-[32]: #clone
+[32]: #get-4
 
-[33]: #help-3
+[33]: #parameters-10
 
-[34]: #get-3
+[34]: #feature
 
-[35]: #parameters-12
+[35]: #help-5
 
-[36]: #deltas
+[36]: #history
 
-[37]: #help-4
+[37]: #parameters-11
 
-[38]: #list-1
+[38]: #key
 
-[39]: #parameters-13
+[39]: #parameters-12
 
-[40]: #get-4
+[40]: #get-5
 
-[41]: #parameters-14
+[41]: #parameters-13
 
-[42]: #feature
+[42]: #arrayreader
 
-[43]: #help-5
+[43]: #parameters-14
 
-[44]: #history
+[44]: #next
 
-[45]: #parameters-15
+[45]: #import
 
-[46]: #key
+[46]: #help-6
 
-[47]: #parameters-16
+[47]: #multi
 
-[48]: #get-5
+[48]: #parameters-15
 
-[49]: #parameters-17
+[49]: #revert
 
-[50]: #arrayreader
+[50]: #help-7
 
-[51]: #parameters-18
+[51]: #deltas-1
 
-[52]: #next
+[52]: #parameters-16
 
-[53]: #import
+[53]: #schema
 
-[54]: #help-6
+[54]: #help-8
 
-[55]: #multi
+[55]: #get-6
 
-[56]: #parameters-19
+[56]: #parameters-17
 
-[57]: #validategeojson
+[57]: #server
 
-[58]: #parameters-20
+[58]: #help-9
 
-[59]: #validatefeature
+[59]: #get-7
 
-[60]: #parameters-21
+[60]: #parameters-18
 
-[61]: #revert
+[61]: #stats-1
 
-[62]: #help-7
+[62]: #parameters-19
 
-[63]: #deltas-1
+[63]: #tiles
 
-[64]: #parameters-22
+[64]: #help-10
 
-[65]: #inverse
+[65]: #get-8
 
-[66]: #parameters-23
+[66]: #parameters-20
 
-[67]: #iterate
+[67]: #user
 
-[68]: #parameters-24
+[68]: #help-11
 
-[69]: #cache
+[69]: #list-2
 
-[70]: #parameters-25
+[70]: #parameters-21
 
-[71]: #deltai
+[71]: #info
 
-[72]: #parameters-26
+[72]: #parameters-22
 
-[73]: #createcache
+[73]: #register
 
-[74]: #cleancache
+[74]: #parameters-23
 
-[75]: #parameters-27
+[75]: #webhooks
 
-[76]: #schema
+[76]: #help-12
 
-[77]: #help-8
+[77]: #list-3
 
-[78]: #get-6
+[78]: #parameters-24
 
-[79]: #parameters-28
+[79]: #get-9
 
-[80]: #server
+[80]: #parameters-25
 
-[81]: #help-9
+[81]: #delete-1
 
-[82]: #get-7
+[82]: #parameters-26
 
-[83]: #parameters-29
+[83]: #update
 
-[84]: #stats-1
+[84]: #parameters-27
 
-[85]: #parameters-30
+[85]: #create
 
-[86]: #tiles
+[86]: #parameters-28
 
-[87]: #help-10
+[87]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/cli.js#L12-L72 "Source code on GitHub"
 
-[88]: #get-8
+[88]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/lib/auth.js#L13-L93 "Source code on GitHub"
 
-[89]: #parameters-31
+[89]: https://github.com/mapbox/hecate#authentication
 
-[90]: #user
+[90]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/lib/auth.js#L26-L35 "Source code on GitHub"
 
-[91]: #help-11
+[91]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/lib/auth.js#L43-L92 "Source code on GitHub"
 
-[92]: #list-2
+[92]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
 
-[93]: #parameters-32
+[93]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
 
-[94]: #info
+[94]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/lib/bbox.js#L17-L158 "Source code on GitHub"
 
-[95]: #parameters-33
+[95]: https://github.com/mapbox/hecate#downloading-multiple-features-via-bbox
 
-[96]: #register
+[96]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/lib/bbox.js#L30-L39 "Source code on GitHub"
 
-[97]: #parameters-34
+[97]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/lib/bbox.js#L55-L157 "Source code on GitHub"
 
-[98]: #webhooks
+[98]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
 
-[99]: #help-12
+[99]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
 
-[100]: #list-3
+[100]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
 
-[101]: #parameters-35
+[101]: https://nodejs.org/api/stream.html
 
-[102]: #get-9
+[102]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/lib/bounds.js#L16-L629 "Source code on GitHub"
 
-[103]: #parameters-36
+[103]: https://github.com/mapbox/hecate#boundaries
 
-[104]: #delete-1
+[104]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/lib/bounds.js#L29-L43 "Source code on GitHub"
 
-[105]: #parameters-37
+[105]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/lib/bounds.js#L53-L139 "Source code on GitHub"
 
-[106]: #update
+[106]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/lib/bounds.js#L149-L225 "Source code on GitHub"
 
-[107]: #parameters-38
+[107]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/lib/bounds.js#L238-L324 "Source code on GitHub"
 
-[108]: #create
+[108]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/lib/bounds.js#L335-L423 "Source code on GitHub"
 
-[109]: #parameters-39
+[109]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/lib/bounds.js#L434-L518 "Source code on GitHub"
 
-[110]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/cli.js#L12-L72 "Source code on GitHub"
+[110]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/lib/bounds.js#L530-L628 "Source code on GitHub"
 
-[111]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/auth.js#L13-L93 "Source code on GitHub"
+[111]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/lib/clone.js#L16-L126 "Source code on GitHub"
 
-[112]: https://github.com/mapbox/hecate#authentication
+[112]: https://github.com/mapbox/hecate#downloading-via-clone
 
-[113]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/auth.js#L26-L35 "Source code on GitHub"
+[113]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/lib/clone.js#L29-L38 "Source code on GitHub"
 
-[114]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/auth.js#L43-L92 "Source code on GitHub"
+[114]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/lib/clone.js#L49-L125 "Source code on GitHub"
 
-[115]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
+[115]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/lib/deltas.js#L15-L242 "Source code on GitHub"
 
-[116]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
+[116]: https://github.com/mapbox/api-geocoder/pull/2634#issuecomment-481255528
 
-[117]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/bbox.js#L17-L158 "Source code on GitHub"
+[117]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/lib/deltas.js#L28-L37 "Source code on GitHub"
 
-[118]: https://github.com/mapbox/hecate#downloading-multiple-features-via-bbox
+[118]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/lib/deltas.js#L49-L145 "Source code on GitHub"
 
-[119]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/bbox.js#L30-L39 "Source code on GitHub"
+[119]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/lib/deltas.js#L155-L241 "Source code on GitHub"
 
-[120]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/bbox.js#L55-L157 "Source code on GitHub"
+[120]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/lib/feature.js#L15-L333 "Source code on GitHub"
 
-[121]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
+[121]: https://github.com/mapbox/hecate#downloading-individual-features
 
-[122]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
+[122]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/lib/feature.js#L28-L38 "Source code on GitHub"
 
-[123]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
+[123]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/lib/feature.js#L50-L136 "Source code on GitHub"
 
-[124]: https://nodejs.org/api/stream.html
+[124]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/lib/feature.js#L148-L234 "Source code on GitHub"
 
-[125]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/util/validateBbox.js#L9-L39 "Source code on GitHub"
+[125]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/lib/feature.js#L246-L332 "Source code on GitHub"
 
-[126]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/util/eot.js#L12-L64 "Source code on GitHub"
+[126]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/lib/import.js#L26-L52 "Source code on GitHub"
 
-[127]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/util/eot.js#L39-L50 "Source code on GitHub"
+[127]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/lib/import.js#L42-L51 "Source code on GitHub"
 
-[128]: https://nodejs.org/api/buffer.html
+[128]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/lib/import.js#L60-L307 "Source code on GitHub"
 
-[129]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/util/eot.js#L59-L63 "Source code on GitHub"
+[129]: https://github.com/mapbox/hecate#feature-creation
 
-[130]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/bounds.js#L16-L629 "Source code on GitHub"
+[130]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/lib/import.js#L73-L86 "Source code on GitHub"
 
-[131]: https://github.com/mapbox/hecate#boundaries
+[131]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/lib/import.js#L102-L306 "Source code on GitHub"
 
-[132]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/bounds.js#L29-L43 "Source code on GitHub"
+[132]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/lib/revert.js#L10-L157 "Source code on GitHub"
 
-[133]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/bounds.js#L53-L139 "Source code on GitHub"
+[133]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/lib/revert.js#L23-L34 "Source code on GitHub"
 
-[134]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/bounds.js#L149-L225 "Source code on GitHub"
+[134]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/lib/revert.js#L48-L156 "Source code on GitHub"
 
-[135]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/bounds.js#L238-L324 "Source code on GitHub"
+[135]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
 
-[136]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/bounds.js#L335-L423 "Source code on GitHub"
+[136]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/lib/schema.js#L15-L127 "Source code on GitHub"
 
-[137]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/bounds.js#L434-L518 "Source code on GitHub"
+[137]: https://github.com/mapbox/hecate#schema
 
-[138]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/bounds.js#L530-L628 "Source code on GitHub"
+[138]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/lib/schema.js#L28-L37 "Source code on GitHub"
 
-[139]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/clone.js#L16-L126 "Source code on GitHub"
+[139]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/lib/schema.js#L47-L126 "Source code on GitHub"
 
-[140]: https://github.com/mapbox/hecate#downloading-via-clone
+[140]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/lib/server.js#L15-L209 "Source code on GitHub"
 
-[141]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/clone.js#L29-L38 "Source code on GitHub"
+[141]: https://github.com/mapbox/hecate#meta
 
-[142]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/clone.js#L49-L125 "Source code on GitHub"
+[142]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/lib/server.js#L28-L38 "Source code on GitHub"
 
-[143]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/deltas.js#L15-L242 "Source code on GitHub"
+[143]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/lib/server.js#L49-L123 "Source code on GitHub"
 
-[144]: https://github.com/mapbox/api-geocoder/pull/2634#issuecomment-481255528
+[144]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/lib/server.js#L134-L208 "Source code on GitHub"
 
-[145]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/deltas.js#L28-L37 "Source code on GitHub"
+[145]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/lib/tiles.js#L15-L134 "Source code on GitHub"
 
-[146]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/deltas.js#L49-L145 "Source code on GitHub"
+[146]: https://github.com/mapbox/hecate#vector-tiles
 
-[147]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/deltas.js#L155-L241 "Source code on GitHub"
+[147]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/lib/tiles.js#L28-L36 "Source code on GitHub"
 
-[148]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/feature.js#L15-L333 "Source code on GitHub"
+[148]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/lib/tiles.js#L48-L133 "Source code on GitHub"
 
-[149]: https://github.com/mapbox/hecate#downloading-individual-features
+[149]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/lib/user.js#L15-L332 "Source code on GitHub"
 
-[150]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/feature.js#L28-L38 "Source code on GitHub"
+[150]: https://github.com/mapbox/hecate#user-options
 
-[151]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/feature.js#L50-L136 "Source code on GitHub"
+[151]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/lib/user.js#L28-L39 "Source code on GitHub"
 
-[152]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/feature.js#L148-L234 "Source code on GitHub"
+[152]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/lib/user.js#L50-L133 "Source code on GitHub"
 
-[153]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/feature.js#L246-L332 "Source code on GitHub"
+[153]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/lib/user.js#L143-L216 "Source code on GitHub"
 
-[154]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/import.js#L26-L52 "Source code on GitHub"
+[154]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/lib/user.js#L229-L331 "Source code on GitHub"
 
-[155]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/import.js#L42-L51 "Source code on GitHub"
+[155]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/lib/webhooks.js#L15-L575 "Source code on GitHub"
 
-[156]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/import.js#L60-L307 "Source code on GitHub"
+[156]: https://github.com/mapbox/hecate#webhooks
 
-[157]: https://github.com/mapbox/hecate#feature-creation
+[157]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/lib/webhooks.js#L28-L41 "Source code on GitHub"
 
-[158]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/import.js#L73-L86 "Source code on GitHub"
+[158]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/lib/webhooks.js#L52-L128 "Source code on GitHub"
 
-[159]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/import.js#L102-L306 "Source code on GitHub"
+[159]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/lib/webhooks.js#L140-L226 "Source code on GitHub"
 
-[160]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/util/validateGeojson.js#L25-L59 "Source code on GitHub"
+[160]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/lib/webhooks.js#L238-L323 "Source code on GitHub"
 
-[161]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/util/validateGeojson.js#L73-L215 "Source code on GitHub"
+[161]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/lib/webhooks.js#L338-L453 "Source code on GitHub"
 
-[162]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
-
-[163]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set
-
-[164]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/revert.js#L10-L157 "Source code on GitHub"
-
-[165]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/revert.js#L23-L34 "Source code on GitHub"
-
-[166]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/revert.js#L48-L156 "Source code on GitHub"
-
-[167]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/util/revert.js#L50-L111 "Source code on GitHub"
-
-[168]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/util/revert.js#L121-L139 "Source code on GitHub"
-
-[169]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/util/revert.js#L154-L219 "Source code on GitHub"
-
-[170]: #hecate
-
-[171]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise
-
-[172]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/util/revert.js#L177-L217 "Source code on GitHub"
-
-[173]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/undefined
-
-[174]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/util/revert.js#L227-L239 "Source code on GitHub"
-
-[175]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/util/revert.js#L248-L254 "Source code on GitHub"
-
-[176]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/schema.js#L15-L127 "Source code on GitHub"
-
-[177]: https://github.com/mapbox/hecate#schema
-
-[178]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/schema.js#L28-L37 "Source code on GitHub"
-
-[179]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/schema.js#L47-L126 "Source code on GitHub"
-
-[180]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/server.js#L15-L209 "Source code on GitHub"
-
-[181]: https://github.com/mapbox/hecate#meta
-
-[182]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/server.js#L28-L38 "Source code on GitHub"
-
-[183]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/server.js#L49-L123 "Source code on GitHub"
-
-[184]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/server.js#L134-L208 "Source code on GitHub"
-
-[185]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/tiles.js#L15-L134 "Source code on GitHub"
-
-[186]: https://github.com/mapbox/hecate#vector-tiles
-
-[187]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/tiles.js#L28-L36 "Source code on GitHub"
-
-[188]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/tiles.js#L48-L133 "Source code on GitHub"
-
-[189]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/user.js#L15-L332 "Source code on GitHub"
-
-[190]: https://github.com/mapbox/hecate#user-options
-
-[191]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/user.js#L28-L39 "Source code on GitHub"
-
-[192]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/user.js#L50-L133 "Source code on GitHub"
-
-[193]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/user.js#L143-L216 "Source code on GitHub"
-
-[194]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/user.js#L229-L331 "Source code on GitHub"
-
-[195]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/webhooks.js#L15-L575 "Source code on GitHub"
-
-[196]: https://github.com/mapbox/hecate#webhooks
-
-[197]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/webhooks.js#L28-L41 "Source code on GitHub"
-
-[198]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/webhooks.js#L52-L128 "Source code on GitHub"
-
-[199]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/webhooks.js#L140-L226 "Source code on GitHub"
-
-[200]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/webhooks.js#L238-L323 "Source code on GitHub"
-
-[201]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/webhooks.js#L338-L453 "Source code on GitHub"
-
-[202]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/webhooks.js#L467-L574 "Source code on GitHub"
+[162]: https://github.com/mapbox/HecateJS/blob/3d90e12738028f4c1a694713d6e31bf2c3ee2a90/lib/webhooks.js#L467-L574 "Source code on GitHub"

--- a/docs/api.md
+++ b/docs/api.md
@@ -4,366 +4,560 @@
 
 -   [Hecate][1]
 -   [Auth][2]
-    -   [get][3]
-        -   [Parameters][4]
--   [BBox][5]
-    -   [get][6]
-        -   [Parameters][7]
--   [validateBbox][8]
-    -   [Parameters][9]
--   [Bounds][10]
-    -   [stats][11]
-        -   [Parameters][12]
-    -   [list][13]
-        -   [Parameters][14]
-    -   [get][15]
-        -   [Parameters][16]
-    -   [meta][17]
-        -   [Parameters][18]
-    -   [delete][19]
-        -   [Parameters][20]
-    -   [set][21]
-        -   [Parameters][22]
--   [Clone][23]
+    -   [help][3]
+    -   [get][4]
+        -   [Parameters][5]
+-   [BBox][6]
+    -   [help][7]
+    -   [get][8]
+        -   [Parameters][9]
+-   [validateBbox][10]
+    -   [Parameters][11]
+-   [EOT][12]
+    -   [Parameters][13]
+    -   [\_transform][14]
+        -   [Parameters][15]
+    -   [\_final][16]
+        -   [Parameters][17]
+-   [Bounds][18]
+    -   [help][19]
+    -   [stats][20]
+        -   [Parameters][21]
+    -   [list][22]
+        -   [Parameters][23]
     -   [get][24]
         -   [Parameters][25]
--   [Deltas][26]
-    -   [list][27]
-        -   [Parameters][28]
-    -   [get][29]
-        -   [Parameters][30]
--   [Feature][31]
-    -   [history][32]
-        -   [Parameters][33]
-    -   [key][34]
+    -   [meta][26]
+        -   [Parameters][27]
+    -   [delete][28]
+        -   [Parameters][29]
+    -   [set][30]
+        -   [Parameters][31]
+-   [Clone][32]
+    -   [help][33]
+    -   [get][34]
         -   [Parameters][35]
-    -   [get][36]
-        -   [Parameters][37]
--   [Import][38]
--   [validateGeojson][39]
-    -   [Parameters][40]
--   [validateFeature][41]
-    -   [Parameters][42]
--   [Revert][43]
-    -   [deltas][44]
+-   [Deltas][36]
+    -   [help][37]
+    -   [list][38]
+        -   [Parameters][39]
+    -   [get][40]
+        -   [Parameters][41]
+-   [Feature][42]
+    -   [help][43]
+    -   [history][44]
         -   [Parameters][45]
--   [inverse][46]
-    -   [Parameters][47]
--   [iterate][48]
-    -   [Parameters][49]
--   [cache][50]
+    -   [key][46]
+        -   [Parameters][47]
+    -   [get][48]
+        -   [Parameters][49]
+-   [ArrayReader][50]
     -   [Parameters][51]
--   [createCache][52]
--   [Schema][53]
--   [Server][54]
-    -   [get][55]
+    -   [next][52]
+-   [Import][53]
+    -   [help][54]
+    -   [multi][55]
         -   [Parameters][56]
-    -   [stats][57]
-        -   [Parameters][58]
--   [Tiles][59]
-    -   [get][60]
-        -   [Parameters][61]
--   [User][62]
--   [Webhooks][63]
-    -   [list][64]
-        -   [Parameters][65]
-    -   [get][66]
-        -   [Parameters][67]
-    -   [delete][68]
-        -   [Parameters][69]
-    -   [update][70]
-        -   [Parameters][71]
-    -   [create][72]
-        -   [Parameters][73]
+-   [validateGeojson][57]
+    -   [Parameters][58]
+-   [validateFeature][59]
+    -   [Parameters][60]
+-   [Revert][61]
+    -   [help][62]
+    -   [deltas][63]
+        -   [Parameters][64]
+-   [inverse][65]
+    -   [Parameters][66]
+-   [iterate][67]
+    -   [Parameters][68]
+-   [cache][69]
+    -   [Parameters][70]
+-   [deltai][71]
+    -   [Parameters][72]
+-   [createCache][73]
+-   [cleanCache][74]
+    -   [Parameters][75]
+-   [Schema][76]
+    -   [help][77]
+    -   [get][78]
+        -   [Parameters][79]
+-   [Server][80]
+    -   [help][81]
+    -   [get][82]
+        -   [Parameters][83]
+    -   [stats][84]
+        -   [Parameters][85]
+-   [Tiles][86]
+    -   [help][87]
+    -   [get][88]
+        -   [Parameters][89]
+-   [User][90]
+    -   [help][91]
+    -   [list][92]
+        -   [Parameters][93]
+    -   [info][94]
+        -   [Parameters][95]
+    -   [register][96]
+        -   [Parameters][97]
+-   [Webhooks][98]
+    -   [help][99]
+    -   [list][100]
+        -   [Parameters][101]
+    -   [get][102]
+        -   [Parameters][103]
+    -   [delete][104]
+        -   [Parameters][105]
+    -   [update][106]
+        -   [Parameters][107]
+    -   [create][108]
+        -   [Parameters][109]
 
 ## Hecate
 
-[cli.js:12-62][74]
+[cli.js:12-72][110]
 
 ## Auth
 
-[lib/auth.js:13-73][75]
+[lib/auth.js:13-93][111]
 
--   **See: [Hecate Documentation][76]**
+-   **See: [Hecate Documentation][112]**
+
+### help
+
+[lib/auth.js:26-35][113]
+
+Print help documentation about the subcommand to stderr
 
 ### get
 
-[lib/auth.js:36-72][77]
+[lib/auth.js:43-92][114]
 
 Return the auth settings for a given hecate instance
 
 #### Parameters
 
--   `options` **![Object][78]** Options for making a request to the auth API (optional, default `{}`)
--   `cb` **[function][79]** (err, res) style callback function
+-   `options` **![Object][115]** Options for making a request to the auth API (optional, default `{}`)
+-   `cb` **[function][116]** (err, res) style callback function
 
 ## BBox
 
-[lib/bbox.js:17-132][80]
+[lib/bbox.js:17-158][117]
 
--   **See: [Hecate Documentation][81]**
+-   **See: [Hecate Documentation][118]**
+
+### help
+
+[lib/bbox.js:30-39][119]
+
+Print help documentation about the subcommand to stderr
 
 ### get
 
-[lib/bbox.js:45-131][82]
+[lib/bbox.js:55-157][120]
 
 Queries hecate /api/data/features endpoint
 Currently supports downloading features by bbox
 
 #### Parameters
 
--   `options` **![Object][78]** Options for making a request to the hecate /api/data/features endpoint (optional, default `{}`)
-    -   `options.history` **[boolean][83]?** [default: false] If true, return current and historic features
+-   `options` **![Object][115]** Options for making a request to the hecate /api/data/features endpoint (optional, default `{}`)
+    -   `options.history` **[boolean][121]?** [default: false] If true, return current and historic features
                                          within the given bbox.
-    -   `options.bbox` **([Array][84] \| [string][85])?** Bounding box of features to download from hecate
-    -   `options.output` **[Stream][86]?** Stream to write line-delimited GeoJSON to
--   `cb` **[function][79]** (err, res) style callback function
+    -   `options.bbox` **([Array][122] \| [string][123])?** Bounding box of features to download from hecate
+    -   `options.output` **[Stream][124]?** Stream to write line-delimited GeoJSON to
+-   `cb` **[function][116]** (err, res) style callback function
+
+Returns **[function][116]** (err, res) style callback
 
 ## validateBbox
 
-[util/validateBbox.js:9-39][87]
+[util/validateBbox.js:9-39][125]
 
 Accepts a bbox as a string or array, and validates (naive with regards to the Antimeridian)
 
 ### Parameters
 
--   `bboxInput` **([Array][84] \| [string][85])** Array in the format [minX,minY,maxX,maxY] or string in the format minX,minY,maxX,maxY
+-   `bboxInput` **([Array][122] \| [string][123])** Array in the format [minX,minY,maxX,maxY] or string in the format minX,minY,maxX,maxY
 
-Returns **[string][85]** String in the format minX,minY,maxX,maxY
+Returns **[string][123]** String in the format minX,minY,maxX,maxY
+
+## EOT
+
+[util/eot.js:12-64][126]
+
+**Extends Transform**
+
+Transform stream to passthrough linedelimited GeoJSON
+and upon termination of the stream, ensure EOT
+character was present to ensure all data was obtained
+
+### Parameters
+
+-   `cb` **[function][116]** (err, res) style callback
+
+### \_transform
+
+[util/eot.js:39-50][127]
+
+Internal transform function to passthrough data
+and look for EOT character
+
+#### Parameters
+
+-   `chunk` **[Buffer][128]** chunk to passthrough
+-   `encoding` **[string][123]** The encoding of the chunk
+-   `done` **[function][116]** completion callback
+
+Returns **[function][116]** callback function
+
+### \_final
+
+[util/eot.js:59-63][129]
+
+Ensure the stream completeled successfully, checking for the EOT character
+
+#### Parameters
+
+-   `done` **[function][116]** completion callback
+
+Returns **[function][116]** (err, res) style callback
 
 ## Bounds
 
-[lib/bounds.js:16-516][88]
+[lib/bounds.js:16-629][130]
 
--   **See: [Hecate Documentation][89]**
+-   **See: [Hecate Documentation][131]**
+
+### help
+
+[lib/bounds.js:29-43][132]
+
+Print help documentation about the subcommand to stderr
 
 ### stats
 
-[lib/bounds.js:44-113][90]
+[lib/bounds.js:53-139][133]
 
 Return stats of geo data within a give bounds
 
 #### Parameters
 
--   `options` **![Object][78]** options for makign a query to the bounds list endpoint (optional, default `{}`)
--   `cb` **[function][79]** (err, res) style callback function
+-   `options` **![Object][115]** options for makign a query to the bounds list endpoint (optional, default `{}`)
+-   `cb` **[function][116]** (err, res) style callback function
+
+Returns **[function][116]** (err, res) style callback
 
 ### list
 
-[lib/bounds.js:122-181][91]
+[lib/bounds.js:149-225][134]
 
 Return a list of the bounds that are currently loaded on the server
 
 #### Parameters
 
--   `options` **![Object][78]** options for makign a query to the bounds list endpoint (optional, default `{}`)
--   `cb` **[function][79]** (err, res) style callback function
+-   `options` **![Object][115]** options for makign a query to the bounds list endpoint (optional, default `{}`)
+-   `cb` **[function][116]** (err, res) style callback function
+
+Returns **[function][116]** (err, res) style callback
 
 ### get
 
-[lib/bounds.js:193-263][92]
+[lib/bounds.js:238-324][135]
 
 Queries the /api/data/bounds endpoints, returning a
 line-delimited stream of GeoJSON Features
 
 #### Parameters
 
--   `options` **![Object][78]** Options for making a request to the bounds endpoint (optional, default `{}`)
-    -   `options.bound` **[String][85]?** Name of the bound to download from
-    -   `options.output` **[Stream][86]?** Stream to write line-delimited GeoJSON to
--   `cb` **[function][79]** (err, res) style callback function
+-   `options` **![Object][115]** Options for making a request to the bounds endpoint (optional, default `{}`)
+    -   `options.bound` **[String][123]?** Name of the bound to download from
+    -   `options.output` **[Stream][124]?** Stream to write line-delimited GeoJSON to
+-   `cb` **[function][116]** (err, res) style callback function
+
+Returns **[function][116]** (err, res) style callback
 
 ### meta
 
-[lib/bounds.js:273-344][93]
+[lib/bounds.js:335-423][136]
 
 Returns underlying bounds geojson for a given bounds
 
 #### Parameters
 
--   `options` **![Object][78]** Options for making a request to the bounds endpoint (optional, default `{}`)
-    -   `options.bound` **[String][85]?** Name of the bound to download from
--   `cb` **[function][79]** (err, res) style callback function
+-   `options` **![Object][115]** Options for making a request to the bounds endpoint (optional, default `{}`)
+    -   `options.bound` **[String][123]?** Name of the bound to download from
+-   `cb` **[function][116]** (err, res) style callback function
+
+Returns **[function][116]** (err, res) style callback
 
 ### delete
 
-[lib/bounds.js:354-422][94]
+[lib/bounds.js:434-518][137]
 
 Delete a boundary file
 
 #### Parameters
 
--   `options` **![Object][78]** Options for making a request to the bounds endpoint (optional, default `{}`)
-    -   `options.bound` **[String][85]?** Name of the bound to download from
--   `cb` **[function][79]** (err, res) style callback function
+-   `options` **![Object][115]** Options for making a request to the bounds endpoint (optional, default `{}`)
+    -   `options.bound` **[String][123]?** Name of the bound to download from
+-   `cb` **[function][116]** (err, res) style callback function
+
+Returns **[function][116]** (err, res) style callback
 
 ### set
 
-[lib/bounds.js:433-515][95]
+[lib/bounds.js:530-628][138]
 
 Create or update a boundary file
 
 #### Parameters
 
--   `options` **![Object][78]** Options for making a request to the bounds endpoint (optional, default `{}`)
-    -   `options.bound` **[String][85]?** Name of the bound to download from
-    -   `options.geom` **[String][85]?** JSON Geometry of bound
--   `cb` **[function][79]** (err, res) style callback function
+-   `options` **![Object][115]** Options for making a request to the bounds endpoint (optional, default `{}`)
+    -   `options.bound` **[String][123]?** Name of the bound to download from
+    -   `options.geom` **[String][123]?** JSON Geometry of bound
+-   `cb` **[function][116]** (err, res) style callback function
+
+Returns **[function][116]** (err, res) style callback
 
 ## Clone
 
-[lib/clone.js:16-101][96]
+[lib/clone.js:16-126][139]
 
--   **See: [Hecate Documentation][97]**
+-   **See: [Hecate Documentation][140]**
+
+### help
+
+[lib/clone.js:29-38][141]
+
+Print help documentation about the subcommand to stderr
 
 ### get
 
-[lib/clone.js:40-100][98]
+[lib/clone.js:49-125][142]
 
 Clone all data on a given hecate server
 
 #### Parameters
 
--   `options` **![Object][78]** Options for making a request to the hecate /api/data/features endpoint (optional, default `{}`)
-    -   `options.output` **[Stream][86]?** Stream to write line-delimited GeoJSON to
--   `cb` **[function][79]** (err, res) style callback function
+-   `options` **![Object][115]** Options for making a request to the hecate /api/data/features endpoint (optional, default `{}`)
+    -   `options.output` **[Stream][124]?** Stream to write line-delimited GeoJSON to
+-   `cb` **[function][116]** (err, res) style callback function
+
+Returns **[function][116]** (err, res) style callback
 
 ## Deltas
 
-[lib/deltas.js:15-198][99]
+[lib/deltas.js:15-242][143]
 
--   **See: [Hecate Documentation][100]**
+-   **See: [Hecate Documentation][144]**
+
+### help
+
+[lib/deltas.js:28-37][145]
+
+Print help documentation about the subcommand to stderr
 
 ### list
 
-[lib/deltas.js:40-119][101]
+[lib/deltas.js:49-145][146]
 
 Queries the recent deltas list, returning the most recent 100 deltas
 
 #### Parameters
 
--   `options` **![Object][78]** Options for making a request to the deltas endpoint (optional, default `{}`)
-    -   `options.limit` **[String][85]** Number of deltas to list by default (optional, default `100`)
-    -   `options.offset` **[String][85]?** delta id to start listing at
--   `cb` **[function][79]** (err, res) style callback function
+-   `options` **![Object][115]** Options for making a request to the deltas endpoint (optional, default `{}`)
+    -   `options.limit` **[String][123]** Number of deltas to list by default (optional, default `100`)
+    -   `options.offset` **[String][123]?** delta id to start listing at
+-   `cb` **[function][116]** (err, res) style callback function
+
+Returns **[function][116]** (err, res) style callback
 
 ### get
 
-[lib/deltas.js:128-197][102]
+[lib/deltas.js:155-241][147]
 
 Returns data about a specific delta
 
 #### Parameters
 
--   `options` **![Object][78]** Options for making a request to the deltas endpoint (optional, default `{}`)
--   `cb` **[function][79]** (err, res) style callback function
+-   `options` **![Object][115]** Options for making a request to the deltas endpoint (optional, default `{}`)
+-   `cb` **[function][116]** (err, res) style callback function
+
+Returns **[function][116]** (err, res) style callback
 
 ## Feature
 
-[lib/feature.js:15-271][103]
+[lib/feature.js:15-333][148]
 
--   **See: [Hecate Documentation][104]**
+-   **See: [Hecate Documentation][149]**
+
+### help
+
+[lib/feature.js:28-38][150]
+
+Print help documentation about the subcommand to stderr
 
 ### history
 
-[lib/feature.js:41-110][105]
+[lib/feature.js:50-136][151]
 
 Queries the feature store endpoint, returning a history of a
 GeoJSON Feature
 
 #### Parameters
 
--   `options` **![Object][78]** Options for making a request to the bounds endpoint (optional, default `{}`)
-    -   `options.feature` **[String][85]?** ID of the feature to download from
--   `cb` **[function][79]** (err, res) style callback function
+-   `options` **![Object][115]** Options for making a request to the bounds endpoint (optional, default `{}`)
+    -   `options.feature` **[String][123]?** ID of the feature to download from
+-   `cb` **[function][116]** (err, res) style callback function
+
+Returns **[function][116]** (err, res) style callback
 
 ### key
 
-[lib/feature.js:121-190][106]
+[lib/feature.js:148-234][152]
 
 Queries the feature store endpoint by key, returning a
 GeoJSON Feature
 
 #### Parameters
 
--   `options` **![Object][78]** Options for making a request to the bounds endpoint (optional, default `{}`)
-    -   `options.feature` **[String][85]?** key of the feature to download from
--   `cb` **[function][79]** (err, res) style callback function
+-   `options` **![Object][115]** Options for making a request to the bounds endpoint (optional, default `{}`)
+    -   `options.feature` **[String][123]?** key of the feature to download from
+-   `cb` **[function][116]** (err, res) style callback function
+
+Returns **[function][116]** (err, res) style callback
 
 ### get
 
-[lib/feature.js:201-270][107]
+[lib/feature.js:246-332][153]
 
 Queries the feature store endpoint, returning a
 GeoJSON Feature
 
 #### Parameters
 
--   `options` **![Object][78]** Options for making a request to the bounds endpoint (optional, default `{}`)
-    -   `options.feature` **[String][85]?** ID of the feature to download from
--   `cb` **[function][79]** (err, res) style callback function
+-   `options` **![Object][115]** Options for making a request to the bounds endpoint (optional, default `{}`)
+    -   `options.feature` **[String][123]?** ID of the feature to download from
+-   `cb` **[function][116]** (err, res) style callback function
+
+Returns **[function][116]** (err, res) style callback
+
+## ArrayReader
+
+[lib/import.js:26-52][154]
+
+Allow features to be passed to the import API as an array
+instead of as a stream
+
+### Parameters
+
+-   `array` **[Array][122]&lt;[Object][115]>** Array of features
+
+### next
+
+[lib/import.js:42-51][155]
+
+Return the next feature in the array, mimics a stream
+
+Returns **[string][123]** GeoJSON Feature to import
 
 ## Import
 
-[lib/import.js:45-238][108]
+[lib/import.js:60-307][156]
 
--   **See: [Hecate Documentation][109]**
+-   **See: [Hecate Documentation][157]**
+
+### help
+
+[lib/import.js:73-86][158]
+
+Print help documentation about the subcommand to stderr
+
+### multi
+
+[lib/import.js:102-306][159]
+
+Given a Stream of line-delimited features or an Array of features, validate and
+import them
+
+#### Parameters
+
+-   `options` **[Object][115]** options object (optional, default `{}`)
+    -   `options.message` **[string][123]** Human readable description of changes
+    -   `options.input` **([string][123] \| [Array][122]&lt;[Object][115]>)** String of filepath or Array containing features to import
+    -   `options.ignoreRHR` **[boolean][121]** Ignore RHR winding errors
+    -   `options.ignoreDup` **[boolean][121]** Don't check duplicate IDs (will usually cause an import failure if they exist)
+    -   `options.dryrun` **[boolean][121]** Perform all validation but don't import
+-   `cb` **[function][116]** (err, res) style callback
+
+Returns **[function][116]** (err, res) style callback
 
 ## validateGeojson
 
-[util/validateGeojson.js:23-57][110]
+[util/validateGeojson.js:25-59][160]
 
 Ensure geometries are valid before import
 
 ### Parameters
 
--   `opts` **[Object][78]** Options object (optional, default `{}`)
-    -   `opts.ignoreRHR` **[boolean][83]** =false Ignore Right Hand Rule errors
-    -   `opts.schema` **[Object][78]** JSON Schema to validate properties against
-    -   `opts.ids` **[boolean][83]** If false, disable duplicate ID checking
+-   `opts` **[Object][115]** Options object (optional, default `{}`)
+    -   `opts.ignoreRHR` **[boolean][121]** =false Ignore Right Hand Rule errors
+    -   `opts.schema` **[Object][115]** JSON Schema to validate properties against
+    -   `opts.ids` **[boolean][121]** If false, disable duplicate ID checking
+
+Returns **[Stream][124]** transform stream to validate GeoJSON
 
 ## validateFeature
 
-[util/validateGeojson.js:71-213][111]
+[util/validateGeojson.js:73-215][161]
 
 Validate a single feature
 
 ### Parameters
 
--   `line` **([Object][78] \| [String][85])** Feature to validate
--   `options` **[Object][78]** 
-    -   `options.ignoreRHR` **[boolean][83]** Ignore winding order
-    -   `options.schema` **[Function][79]** AJV Function to validate feature properties against a JSON Schema
-    -   `options.linenumber` **[number][112]** Linenumber to output in error object
-    -   `options.ids` **[Set][113]** Set to keep track of feature id duplicates
+-   `line` **([Object][115] \| [string][123])** Feature to validate
+-   `options` **[Object][115]** Validation Options
+    -   `options.ignoreRHR` **[boolean][121]** Ignore winding order
+    -   `options.schema` **[Function][116]** AJV Function to validate feature properties against a JSON Schema
+    -   `options.linenumber` **[number][162]** Linenumber to output in error object
+    -   `options.ids` **[Set][163]** Set to keep track of feature id duplicates
 
-Returns **[Array][84]** Array of errors (empty array if none)
+Returns **[Array][122]** Array of errors (empty array if none)
 
 ## Revert
 
-[lib/revert.js:10-127][114]
+[lib/revert.js:10-157][164]
+
+### help
+
+[lib/revert.js:23-34][165]
+
+Print help documentation about the subcommand to stderr
 
 ### deltas
 
-[lib/revert.js:38-126][115]
+[lib/revert.js:48-156][166]
 
 Revert a given set of deltas
 
 #### Parameters
 
--   `options` **![Object][78]** options for making reversion of a set of deltas (optional, default `{}`)
-    -   `options.start` **[Number][112]** Incusive start delta ID to revert
-    -   `options.end` **[Number][112]** inclusive end delta ID to revert
-    -   `options.output` **[Stream][86]?** Stream to write line-delimited GeoJSON to
--   `cb` **[function][79]** (err, res) style callback function
+-   `options` **![Object][115]** Options for making reversion of a set of deltas (optional, default `{}`)
+    -   `options.start` **[number][162]** Inclusive start delta ID to revert
+    -   `options.end` **[number][162]** Inclusive end delta ID to revert
+    -   `options.output` **[Stream][124]?** Stream to write line-delimited GeoJSON to
+-   `cb` **[function][116]** (err, res) style callback function
+
+Returns **[function][116]** (err, res) style callback
 
 ## inverse
 
-[util/revert.js:48-109][116]
+[util/revert.js:50-111][167]
 
-Given the feature history for a single feature,
-revert the last feature in the history to that
-of the second last
+Given the feature history for a single feature and the version of the feature
+to be reverted, calculate a feature that can be uploaded which will
+restore the state of the feature to that of the version preceding
+the version supplied
 
 Example:
 
@@ -396,14 +590,14 @@ and versioning
 
 ### Parameters
 
--   `history`  
--   `version` **[Number][112]** feature version that should be rolled back
+-   `history` **[Array][122]&lt;[Object][115]>** Array of features accross all verisons of the feature
+-   `version` **[number][162]** feature version that should be rolled back
 
-Returns **[Object][78]** Returns calculated inverse feature
+Returns **[Object][115]** Returns calculated inverse feature
 
 ## iterate
 
-[util/revert.js:119-137][117]
+[util/revert.js:121-139][168]
 
 Iterate over Sqlite3 database containing features to revert to previous state
 
@@ -411,12 +605,12 @@ Writes inversion to given writable stream
 
 ### Parameters
 
--   `db` **[Object][78]** sqlite3 db to iterate over
--   `stream` **[Stream][86]** output stream to write inverted features to
+-   `db` **[Object][115]** sqlite3 db to iterate over
+-   `stream` **[Stream][124]** output stream to write inverted features to
 
 ## cache
 
-[util/revert.js:150-186][118]
+[util/revert.js:154-219][169]
 
 Given a start/end range for a set of deltas, download
 each of the deltas, then iterate through each feature,
@@ -424,422 +618,678 @@ retreiving it's history and writing it to disk
 
 ### Parameters
 
--   `options` **[Object][78]** options object
-    -   `options.start` **[Number][112]** Delta Start ID
-    -   `options.end` **[Number][112]** Delta End ID
--   `api`  
+-   `options` **[Object][115]** options object
+    -   `options.start` **[number][162]** Delta Start ID
+    -   `options.end` **[number][162]** Delta End ID
+-   `api` **[Hecate][170]** Hecate Instance for API calls
 
-Returns **[Promise][119]** 
+Returns **[Promise][171]** Promise containing db instance or error
+
+## deltai
+
+[util/revert.js:177-217][172]
+
+Retrieve a single delta at a time, and then
+each of it's component feature histories in parallem
+commiting each to the database
+
+### Parameters
+
+-   `i` **[number][162]** delta ID last retrieved
+
+Returns **[undefined][173]** 
 
 ## createCache
 
-[util/revert.js:194-206][120]
+[util/revert.js:227-239][174]
 
 Create a new reversion sqlite3 database, initialize it with table
 definitions, and pass back db object to caller
 
-Returns **[Object][78]** Sqlite3 Database Handler
+Returns **[Object][115]** Sqlite3 Database Handler
+
+## cleanCache
+
+[util/revert.js:248-254][175]
+
+Given a sqlite instance, close and delete it
+
+### Parameters
+
+-   `db` **[Object][115]** sqlite3 database instance
+
+Returns **[undefined][173]** 
 
 ## Schema
 
-[lib/schema.js:15-94][121]
+[lib/schema.js:15-127][176]
 
--   **See: [Hecate Documentation][122]**
+-   **See: [Hecate Documentation][177]**
 
-## Server
+### help
 
-[lib/server.js:15-163][123]
+[lib/schema.js:28-37][178]
 
--   **See: [Hecate Documentation][124]**
+Print help documentation about the subcommand to stderr
 
 ### get
 
-[lib/server.js:39-96][125]
+[lib/schema.js:47-126][179]
+
+Retrieve a JSON schema that feature properties must conform to
+
+#### Parameters
+
+-   `options` **[Object][115]** options object (optional, default `{}`)
+-   `cb` **[function][116]** (err, res) style callback
+
+Returns **[function][116]** (err, res) style callback
+
+## Server
+
+[lib/server.js:15-209][180]
+
+-   **See: [Hecate Documentation][181]**
+
+### help
+
+[lib/server.js:28-38][182]
+
+Print help documentation about the subcommand to stderr
+
+### get
+
+[lib/server.js:49-123][183]
 
 Get server metadata
 
 #### Parameters
 
--   `options` **![Object][78]** Options for making a request to meta API (optional, default `{}`)
--   `cb` **[function][79]** (err, res) style callback function
+-   `options` **![Object][115]** Options for making a request to meta API (optional, default `{}`)
+-   `cb` **[function][116]** (err, res) style callback function
+
+Returns **[function][116]** (err, res) style callback
 
 ### stats
 
-[lib/server.js:105-162][126]
+[lib/server.js:134-208][184]
 
 Get server stats
 
 #### Parameters
 
--   `options` **![Object][78]** Options for making a request to meta API (optional, default `{}`)
--   `cb` **[function][79]** (err, res) style callback function
+-   `options` **![Object][115]** Options for making a request to meta API (optional, default `{}`)
+-   `cb` **[function][116]** (err, res) style callback function
+
+Returns **[function][116]** (err, res) style callback
 
 ## Tiles
 
-[lib/tiles.js:15-108][127]
+[lib/tiles.js:15-134][185]
 
--   **See: [Hecate Documentation][128]**
+-   **See: [Hecate Documentation][186]**
+
+### help
+
+[lib/tiles.js:28-36][187]
+
+Print help documentation about the subcommand to stderr
 
 ### get
 
-[lib/tiles.js:38-107][129]
+[lib/tiles.js:48-133][188]
 
 Fetch a Mapbox Vector Tile for the given zxy
 
 #### Parameters
 
--   `options` **![Object][78]** Options for making a request to the deltas endpoint (optional, default `{}`)
-    -   `options.zxy` **[String][85]?** z/x/y coordinate to request
--   `cb` **[function][79]** (err, res) style callback function
+-   `options` **![Object][115]** Options for making a request to the deltas endpoint (optional, default `{}`)
+    -   `options.zxy` **[String][123]?** z/x/y coordinate to request
+-   `cb` **[function][116]** (err, res) style callback function
+
+Returns **[function][116]** (err, res) style callback
 
 ## User
 
-[lib/user.js:15-246][130]
+[lib/user.js:15-332][189]
 
--   **See: [Hecate Documentation][131]**
+-   **See: [Hecate Documentation][190]**
 
-## Webhooks
+### help
 
-[lib/webhooks.js:15-475][132]
+[lib/user.js:28-39][191]
 
--   **See: [Hecate Documentation][133]**
+Print help documentation about the subcommand to stderr
 
 ### list
 
-[lib/webhooks.js:42-101][134]
+[lib/user.js:50-133][192]
+
+List users with optional filtering
+
+#### Parameters
+
+-   `options` **[Object][115]** Options object (optional, default `{}`)
+    -   `options.filter` **[string][123]** User prefix to filter by
+-   `cb` **[function][116]** (err, res) style callback
+
+Returns **[function][116]** (err, res) style callback
+
+### info
+
+[lib/user.js:143-216][193]
+
+Retrieve metadata about the user that makes the request
+
+#### Parameters
+
+-   `options` **[Object][115]** options object (optional, default `{}`)
+-   `cb` **[function][116]** (err, res) style callback
+
+Returns **[function][116]** (err, res) style callback
+
+### register
+
+[lib/user.js:229-331][194]
+
+Register a new user account
+
+#### Parameters
+
+-   `options` **[Object][115]** options object (optional, default `{}`)
+    -   `options.username` **[string][123]** Username to register
+    -   `options.email` **[string][123]** Email of account to register
+    -   `options.password` **[string][123]** Password of account to register
+-   `cb` **[function][116]** (err, res) style callback
+
+Returns **[function][116]** (err, res) style callback
+
+## Webhooks
+
+[lib/webhooks.js:15-575][195]
+
+-   **See: [Hecate Documentation][196]**
+
+### help
+
+[lib/webhooks.js:28-41][197]
+
+Print help documentation about the subcommand to stderr
+
+### list
+
+[lib/webhooks.js:52-128][198]
 
 Queries hecate /api/webhooks endpoint
 
 #### Parameters
 
--   `options` **![Object][78]** Options for making a request to the hecate /api/webhooks endpoint (optional, default `{}`)
--   `cb` **[function][79]** (err, res) style callback function
+-   `options` **![Object][115]** Options for making a request to the hecate /api/webhooks endpoint (optional, default `{}`)
+-   `cb` **[function][116]** (err, res) style callback function
+
+Returns **[function][116]** (err, res) style callback
 
 ### get
 
-[lib/webhooks.js:111-180][135]
+[lib/webhooks.js:140-226][199]
 
 Get a specific webhook given the ID
 
 #### Parameters
 
--   `options` **![Object][78]** Options for making a request to the hecate /api/webhooks endpoint (optional, default `{}`)
-    -   `options.id` **[Number][112]** ID of the webhook to retreive
--   `cb` **[function][79]** (err, res) style callback function
+-   `options` **![Object][115]** Options for making a request to the hecate /api/webhooks endpoint (optional, default `{}`)
+    -   `options.id` **[number][162]** ID of the webhook to retreive
+-   `cb` **[function][116]** (err, res) style callback function
+
+Returns **[function][116]** (err, res) style callback function
 
 ### delete
 
-[lib/webhooks.js:190-259][136]
+[lib/webhooks.js:238-323][200]
 
 Delete a specific webhook given the ID
 
 #### Parameters
 
--   `options` **![Object][78]** Options for making a request to the hecate /api/webhooks endpoint (optional, default `{}`)
-    -   `options.id` **[Number][112]** ID of the webhook to delete
--   `cb` **[function][79]** (err, res) style callback function
+-   `options` **![Object][115]** Options for making a request to the hecate /api/webhooks endpoint (optional, default `{}`)
+    -   `options.id` **[number][162]** ID of the webhook to delete
+-   `cb` **[function][116]** (err, res) style callback function
+
+Returns **[function][116]** (err, res) style callback function
 
 ### update
 
-[lib/webhooks.js:272-371][137]
+[lib/webhooks.js:338-453][201]
 
 Update a given webhook ID
 
 #### Parameters
 
--   `options` **![Object][78]** Options for making a request to the hecate /api/webhooks endpoint (optional, default `{}`)
-    -   `options.id` **[Number][112]** ID of the webhook to update
-    -   `options.name` **[String][85]** Name of the webhook
-    -   `options.url` **[String][85]** URL of the webhook
-    -   `options.actions` **[Array][84]&lt;[String][85]>** server actions the webhook should be fired on
--   `cb` **[function][79]** (err, res) style callback function
+-   `options` **![Object][115]** Options for making a request to the hecate /api/webhooks endpoint (optional, default `{}`)
+    -   `options.id` **[number][162]** ID of the webhook to update
+    -   `options.name` **[string][123]** Name of the webhook
+    -   `options.url` **[string][123]** URL of the webhook
+    -   `options.actions` **[Array][122]&lt;[string][123]>** server actions the webhook should be fired on
+-   `cb` **[function][116]** (err, res) style callback function
+
+Returns **[function][116]** (err, res) style callback function
 
 ### create
 
-[lib/webhooks.js:383-474][138]
+[lib/webhooks.js:467-574][202]
 
 Create a new webhook
 
 #### Parameters
 
--   `options` **![Object][78]** Options for making a request to the hecate /api/webhooks endpoint (optional, default `{}`)
-    -   `options.name` **[String][85]** Name of the webhook
-    -   `options.url` **[String][85]** URL of the webhook
-    -   `options.actions` **[Array][84]&lt;[String][85]>** server actions the webhook should be fired on
--   `cb` **[function][79]** (err, res) style callback function
+-   `options` **![Object][115]** Options for making a request to the hecate /api/webhooks endpoint (optional, default `{}`)
+    -   `options.name` **[string][123]** Name of the webhook
+    -   `options.url` **[string][123]** URL of the webhook
+    -   `options.actions` **[Array][122]&lt;[string][123]>** server actions the webhook should be fired on
+-   `cb` **[function][116]** (err, res) style callback function
+
+Returns **[function][116]** (err, res) style callback function
 
 [1]: #hecate
 
 [2]: #auth
 
-[3]: #get
+[3]: #help
 
-[4]: #parameters
+[4]: #get
 
-[5]: #bbox
+[5]: #parameters
 
-[6]: #get-1
+[6]: #bbox
 
-[7]: #parameters-1
+[7]: #help-1
 
-[8]: #validatebbox
+[8]: #get-1
 
-[9]: #parameters-2
+[9]: #parameters-1
 
-[10]: #bounds
+[10]: #validatebbox
 
-[11]: #stats
+[11]: #parameters-2
 
-[12]: #parameters-3
+[12]: #eot
 
-[13]: #list
+[13]: #parameters-3
 
-[14]: #parameters-4
+[14]: #_transform
 
-[15]: #get-2
+[15]: #parameters-4
 
-[16]: #parameters-5
+[16]: #_final
 
-[17]: #meta
+[17]: #parameters-5
 
-[18]: #parameters-6
+[18]: #bounds
 
-[19]: #delete
+[19]: #help-2
 
-[20]: #parameters-7
+[20]: #stats
 
-[21]: #set
+[21]: #parameters-6
 
-[22]: #parameters-8
+[22]: #list
 
-[23]: #clone
+[23]: #parameters-7
 
-[24]: #get-3
+[24]: #get-2
 
-[25]: #parameters-9
+[25]: #parameters-8
 
-[26]: #deltas
+[26]: #meta
 
-[27]: #list-1
+[27]: #parameters-9
 
-[28]: #parameters-10
+[28]: #delete
 
-[29]: #get-4
+[29]: #parameters-10
 
-[30]: #parameters-11
+[30]: #set
 
-[31]: #feature
+[31]: #parameters-11
 
-[32]: #history
+[32]: #clone
 
-[33]: #parameters-12
+[33]: #help-3
 
-[34]: #key
+[34]: #get-3
 
-[35]: #parameters-13
+[35]: #parameters-12
 
-[36]: #get-5
+[36]: #deltas
 
-[37]: #parameters-14
+[37]: #help-4
 
-[38]: #import
+[38]: #list-1
 
-[39]: #validategeojson
+[39]: #parameters-13
 
-[40]: #parameters-15
+[40]: #get-4
 
-[41]: #validatefeature
+[41]: #parameters-14
 
-[42]: #parameters-16
+[42]: #feature
 
-[43]: #revert
+[43]: #help-5
 
-[44]: #deltas-1
+[44]: #history
 
-[45]: #parameters-17
+[45]: #parameters-15
 
-[46]: #inverse
+[46]: #key
 
-[47]: #parameters-18
+[47]: #parameters-16
 
-[48]: #iterate
+[48]: #get-5
 
-[49]: #parameters-19
+[49]: #parameters-17
 
-[50]: #cache
+[50]: #arrayreader
 
-[51]: #parameters-20
+[51]: #parameters-18
 
-[52]: #createcache
+[52]: #next
 
-[53]: #schema
+[53]: #import
 
-[54]: #server
+[54]: #help-6
 
-[55]: #get-6
+[55]: #multi
 
-[56]: #parameters-21
+[56]: #parameters-19
 
-[57]: #stats-1
+[57]: #validategeojson
 
-[58]: #parameters-22
+[58]: #parameters-20
 
-[59]: #tiles
+[59]: #validatefeature
 
-[60]: #get-7
+[60]: #parameters-21
 
-[61]: #parameters-23
+[61]: #revert
 
-[62]: #user
+[62]: #help-7
 
-[63]: #webhooks
+[63]: #deltas-1
 
-[64]: #list-2
+[64]: #parameters-22
 
-[65]: #parameters-24
+[65]: #inverse
 
-[66]: #get-8
+[66]: #parameters-23
 
-[67]: #parameters-25
+[67]: #iterate
 
-[68]: #delete-1
+[68]: #parameters-24
 
-[69]: #parameters-26
+[69]: #cache
 
-[70]: #update
+[70]: #parameters-25
 
-[71]: #parameters-27
+[71]: #deltai
 
-[72]: #create
+[72]: #parameters-26
 
-[73]: #parameters-28
+[73]: #createcache
 
-[74]: https://github.com/mapbox/HecateJS/blob/0b258ac1930da1ebcfa45abc4a9d7ebcb2084f8a/cli.js#L12-L62 "Source code on GitHub"
+[74]: #cleancache
 
-[75]: https://github.com/mapbox/HecateJS/blob/0b258ac1930da1ebcfa45abc4a9d7ebcb2084f8a/lib/auth.js#L13-L73 "Source code on GitHub"
+[75]: #parameters-27
 
-[76]: https://github.com/mapbox/hecate#authentication
+[76]: #schema
 
-[77]: https://github.com/mapbox/HecateJS/blob/0b258ac1930da1ebcfa45abc4a9d7ebcb2084f8a/lib/auth.js#L36-L72 "Source code on GitHub"
+[77]: #help-8
 
-[78]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
+[78]: #get-6
 
-[79]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
+[79]: #parameters-28
 
-[80]: https://github.com/mapbox/HecateJS/blob/0b258ac1930da1ebcfa45abc4a9d7ebcb2084f8a/lib/bbox.js#L17-L132 "Source code on GitHub"
+[80]: #server
 
-[81]: https://github.com/mapbox/hecate#downloading-multiple-features-via-bbox
+[81]: #help-9
 
-[82]: https://github.com/mapbox/HecateJS/blob/0b258ac1930da1ebcfa45abc4a9d7ebcb2084f8a/lib/bbox.js#L45-L131 "Source code on GitHub"
+[82]: #get-7
 
-[83]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
+[83]: #parameters-29
 
-[84]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
+[84]: #stats-1
 
-[85]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
+[85]: #parameters-30
 
-[86]: https://nodejs.org/api/stream.html
+[86]: #tiles
 
-[87]: https://github.com/mapbox/HecateJS/blob/0b258ac1930da1ebcfa45abc4a9d7ebcb2084f8a/util/validateBbox.js#L9-L39 "Source code on GitHub"
+[87]: #help-10
 
-[88]: https://github.com/mapbox/HecateJS/blob/0b258ac1930da1ebcfa45abc4a9d7ebcb2084f8a/lib/bounds.js#L16-L516 "Source code on GitHub"
+[88]: #get-8
 
-[89]: https://github.com/mapbox/hecate#boundaries
+[89]: #parameters-31
 
-[90]: https://github.com/mapbox/HecateJS/blob/0b258ac1930da1ebcfa45abc4a9d7ebcb2084f8a/lib/bounds.js#L44-L113 "Source code on GitHub"
+[90]: #user
 
-[91]: https://github.com/mapbox/HecateJS/blob/0b258ac1930da1ebcfa45abc4a9d7ebcb2084f8a/lib/bounds.js#L122-L181 "Source code on GitHub"
+[91]: #help-11
 
-[92]: https://github.com/mapbox/HecateJS/blob/0b258ac1930da1ebcfa45abc4a9d7ebcb2084f8a/lib/bounds.js#L193-L263 "Source code on GitHub"
+[92]: #list-2
 
-[93]: https://github.com/mapbox/HecateJS/blob/0b258ac1930da1ebcfa45abc4a9d7ebcb2084f8a/lib/bounds.js#L273-L344 "Source code on GitHub"
+[93]: #parameters-32
 
-[94]: https://github.com/mapbox/HecateJS/blob/0b258ac1930da1ebcfa45abc4a9d7ebcb2084f8a/lib/bounds.js#L354-L422 "Source code on GitHub"
+[94]: #info
 
-[95]: https://github.com/mapbox/HecateJS/blob/0b258ac1930da1ebcfa45abc4a9d7ebcb2084f8a/lib/bounds.js#L433-L515 "Source code on GitHub"
+[95]: #parameters-33
 
-[96]: https://github.com/mapbox/HecateJS/blob/0b258ac1930da1ebcfa45abc4a9d7ebcb2084f8a/lib/clone.js#L16-L101 "Source code on GitHub"
+[96]: #register
 
-[97]: https://github.com/mapbox/hecate#downloading-via-clone
+[97]: #parameters-34
 
-[98]: https://github.com/mapbox/HecateJS/blob/0b258ac1930da1ebcfa45abc4a9d7ebcb2084f8a/lib/clone.js#L40-L100 "Source code on GitHub"
+[98]: #webhooks
 
-[99]: https://github.com/mapbox/HecateJS/blob/0b258ac1930da1ebcfa45abc4a9d7ebcb2084f8a/lib/deltas.js#L15-L198 "Source code on GitHub"
+[99]: #help-12
 
-[100]: https://github.com/mapbox/api-geocoder/pull/2634#issuecomment-481255528
+[100]: #list-3
 
-[101]: https://github.com/mapbox/HecateJS/blob/0b258ac1930da1ebcfa45abc4a9d7ebcb2084f8a/lib/deltas.js#L40-L119 "Source code on GitHub"
+[101]: #parameters-35
 
-[102]: https://github.com/mapbox/HecateJS/blob/0b258ac1930da1ebcfa45abc4a9d7ebcb2084f8a/lib/deltas.js#L128-L197 "Source code on GitHub"
+[102]: #get-9
 
-[103]: https://github.com/mapbox/HecateJS/blob/0b258ac1930da1ebcfa45abc4a9d7ebcb2084f8a/lib/feature.js#L15-L271 "Source code on GitHub"
+[103]: #parameters-36
 
-[104]: https://github.com/mapbox/hecate#downloading-individual-features
+[104]: #delete-1
 
-[105]: https://github.com/mapbox/HecateJS/blob/0b258ac1930da1ebcfa45abc4a9d7ebcb2084f8a/lib/feature.js#L41-L110 "Source code on GitHub"
+[105]: #parameters-37
 
-[106]: https://github.com/mapbox/HecateJS/blob/0b258ac1930da1ebcfa45abc4a9d7ebcb2084f8a/lib/feature.js#L121-L190 "Source code on GitHub"
+[106]: #update
 
-[107]: https://github.com/mapbox/HecateJS/blob/0b258ac1930da1ebcfa45abc4a9d7ebcb2084f8a/lib/feature.js#L201-L270 "Source code on GitHub"
+[107]: #parameters-38
 
-[108]: https://github.com/mapbox/HecateJS/blob/0b258ac1930da1ebcfa45abc4a9d7ebcb2084f8a/lib/import.js#L45-L238 "Source code on GitHub"
+[108]: #create
 
-[109]: https://github.com/mapbox/hecate#feature-creation
+[109]: #parameters-39
 
-[110]: https://github.com/mapbox/HecateJS/blob/0b258ac1930da1ebcfa45abc4a9d7ebcb2084f8a/util/validateGeojson.js#L23-L57 "Source code on GitHub"
+[110]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/cli.js#L12-L72 "Source code on GitHub"
 
-[111]: https://github.com/mapbox/HecateJS/blob/0b258ac1930da1ebcfa45abc4a9d7ebcb2084f8a/util/validateGeojson.js#L71-L213 "Source code on GitHub"
+[111]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/auth.js#L13-L93 "Source code on GitHub"
 
-[112]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
+[112]: https://github.com/mapbox/hecate#authentication
 
-[113]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set
+[113]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/auth.js#L26-L35 "Source code on GitHub"
 
-[114]: https://github.com/mapbox/HecateJS/blob/0b258ac1930da1ebcfa45abc4a9d7ebcb2084f8a/lib/revert.js#L10-L127 "Source code on GitHub"
+[114]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/auth.js#L43-L92 "Source code on GitHub"
 
-[115]: https://github.com/mapbox/HecateJS/blob/0b258ac1930da1ebcfa45abc4a9d7ebcb2084f8a/lib/revert.js#L38-L126 "Source code on GitHub"
+[115]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
 
-[116]: https://github.com/mapbox/HecateJS/blob/0b258ac1930da1ebcfa45abc4a9d7ebcb2084f8a/util/revert.js#L48-L109 "Source code on GitHub"
+[116]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
 
-[117]: https://github.com/mapbox/HecateJS/blob/0b258ac1930da1ebcfa45abc4a9d7ebcb2084f8a/util/revert.js#L119-L137 "Source code on GitHub"
+[117]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/bbox.js#L17-L158 "Source code on GitHub"
 
-[118]: https://github.com/mapbox/HecateJS/blob/0b258ac1930da1ebcfa45abc4a9d7ebcb2084f8a/util/revert.js#L150-L186 "Source code on GitHub"
+[118]: https://github.com/mapbox/hecate#downloading-multiple-features-via-bbox
 
-[119]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise
+[119]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/bbox.js#L30-L39 "Source code on GitHub"
 
-[120]: https://github.com/mapbox/HecateJS/blob/0b258ac1930da1ebcfa45abc4a9d7ebcb2084f8a/util/revert.js#L194-L206 "Source code on GitHub"
+[120]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/bbox.js#L55-L157 "Source code on GitHub"
 
-[121]: https://github.com/mapbox/HecateJS/blob/0b258ac1930da1ebcfa45abc4a9d7ebcb2084f8a/lib/schema.js#L15-L94 "Source code on GitHub"
+[121]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
 
-[122]: https://github.com/mapbox/hecate#schema
+[122]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
 
-[123]: https://github.com/mapbox/HecateJS/blob/0b258ac1930da1ebcfa45abc4a9d7ebcb2084f8a/lib/server.js#L15-L163 "Source code on GitHub"
+[123]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
 
-[124]: https://github.com/mapbox/hecate#meta
+[124]: https://nodejs.org/api/stream.html
 
-[125]: https://github.com/mapbox/HecateJS/blob/0b258ac1930da1ebcfa45abc4a9d7ebcb2084f8a/lib/server.js#L39-L96 "Source code on GitHub"
+[125]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/util/validateBbox.js#L9-L39 "Source code on GitHub"
 
-[126]: https://github.com/mapbox/HecateJS/blob/0b258ac1930da1ebcfa45abc4a9d7ebcb2084f8a/lib/server.js#L105-L162 "Source code on GitHub"
+[126]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/util/eot.js#L12-L64 "Source code on GitHub"
 
-[127]: https://github.com/mapbox/HecateJS/blob/0b258ac1930da1ebcfa45abc4a9d7ebcb2084f8a/lib/tiles.js#L15-L108 "Source code on GitHub"
+[127]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/util/eot.js#L39-L50 "Source code on GitHub"
 
-[128]: https://github.com/mapbox/hecate#vector-tiles
+[128]: https://nodejs.org/api/buffer.html
 
-[129]: https://github.com/mapbox/HecateJS/blob/0b258ac1930da1ebcfa45abc4a9d7ebcb2084f8a/lib/tiles.js#L38-L107 "Source code on GitHub"
+[129]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/util/eot.js#L59-L63 "Source code on GitHub"
 
-[130]: https://github.com/mapbox/HecateJS/blob/0b258ac1930da1ebcfa45abc4a9d7ebcb2084f8a/lib/user.js#L15-L246 "Source code on GitHub"
+[130]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/bounds.js#L16-L629 "Source code on GitHub"
 
-[131]: https://github.com/mapbox/hecate#user-options
+[131]: https://github.com/mapbox/hecate#boundaries
 
-[132]: https://github.com/mapbox/HecateJS/blob/0b258ac1930da1ebcfa45abc4a9d7ebcb2084f8a/lib/webhooks.js#L15-L475 "Source code on GitHub"
+[132]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/bounds.js#L29-L43 "Source code on GitHub"
 
-[133]: https://github.com/mapbox/hecate#webhooks
+[133]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/bounds.js#L53-L139 "Source code on GitHub"
 
-[134]: https://github.com/mapbox/HecateJS/blob/0b258ac1930da1ebcfa45abc4a9d7ebcb2084f8a/lib/webhooks.js#L42-L101 "Source code on GitHub"
+[134]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/bounds.js#L149-L225 "Source code on GitHub"
 
-[135]: https://github.com/mapbox/HecateJS/blob/0b258ac1930da1ebcfa45abc4a9d7ebcb2084f8a/lib/webhooks.js#L111-L180 "Source code on GitHub"
+[135]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/bounds.js#L238-L324 "Source code on GitHub"
 
-[136]: https://github.com/mapbox/HecateJS/blob/0b258ac1930da1ebcfa45abc4a9d7ebcb2084f8a/lib/webhooks.js#L190-L259 "Source code on GitHub"
+[136]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/bounds.js#L335-L423 "Source code on GitHub"
 
-[137]: https://github.com/mapbox/HecateJS/blob/0b258ac1930da1ebcfa45abc4a9d7ebcb2084f8a/lib/webhooks.js#L272-L371 "Source code on GitHub"
+[137]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/bounds.js#L434-L518 "Source code on GitHub"
 
-[138]: https://github.com/mapbox/HecateJS/blob/0b258ac1930da1ebcfa45abc4a9d7ebcb2084f8a/lib/webhooks.js#L383-L474 "Source code on GitHub"
+[138]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/bounds.js#L530-L628 "Source code on GitHub"
+
+[139]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/clone.js#L16-L126 "Source code on GitHub"
+
+[140]: https://github.com/mapbox/hecate#downloading-via-clone
+
+[141]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/clone.js#L29-L38 "Source code on GitHub"
+
+[142]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/clone.js#L49-L125 "Source code on GitHub"
+
+[143]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/deltas.js#L15-L242 "Source code on GitHub"
+
+[144]: https://github.com/mapbox/api-geocoder/pull/2634#issuecomment-481255528
+
+[145]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/deltas.js#L28-L37 "Source code on GitHub"
+
+[146]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/deltas.js#L49-L145 "Source code on GitHub"
+
+[147]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/deltas.js#L155-L241 "Source code on GitHub"
+
+[148]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/feature.js#L15-L333 "Source code on GitHub"
+
+[149]: https://github.com/mapbox/hecate#downloading-individual-features
+
+[150]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/feature.js#L28-L38 "Source code on GitHub"
+
+[151]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/feature.js#L50-L136 "Source code on GitHub"
+
+[152]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/feature.js#L148-L234 "Source code on GitHub"
+
+[153]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/feature.js#L246-L332 "Source code on GitHub"
+
+[154]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/import.js#L26-L52 "Source code on GitHub"
+
+[155]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/import.js#L42-L51 "Source code on GitHub"
+
+[156]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/import.js#L60-L307 "Source code on GitHub"
+
+[157]: https://github.com/mapbox/hecate#feature-creation
+
+[158]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/import.js#L73-L86 "Source code on GitHub"
+
+[159]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/import.js#L102-L306 "Source code on GitHub"
+
+[160]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/util/validateGeojson.js#L25-L59 "Source code on GitHub"
+
+[161]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/util/validateGeojson.js#L73-L215 "Source code on GitHub"
+
+[162]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
+
+[163]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set
+
+[164]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/revert.js#L10-L157 "Source code on GitHub"
+
+[165]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/revert.js#L23-L34 "Source code on GitHub"
+
+[166]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/revert.js#L48-L156 "Source code on GitHub"
+
+[167]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/util/revert.js#L50-L111 "Source code on GitHub"
+
+[168]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/util/revert.js#L121-L139 "Source code on GitHub"
+
+[169]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/util/revert.js#L154-L219 "Source code on GitHub"
+
+[170]: #hecate
+
+[171]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise
+
+[172]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/util/revert.js#L177-L217 "Source code on GitHub"
+
+[173]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/undefined
+
+[174]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/util/revert.js#L227-L239 "Source code on GitHub"
+
+[175]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/util/revert.js#L248-L254 "Source code on GitHub"
+
+[176]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/schema.js#L15-L127 "Source code on GitHub"
+
+[177]: https://github.com/mapbox/hecate#schema
+
+[178]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/schema.js#L28-L37 "Source code on GitHub"
+
+[179]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/schema.js#L47-L126 "Source code on GitHub"
+
+[180]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/server.js#L15-L209 "Source code on GitHub"
+
+[181]: https://github.com/mapbox/hecate#meta
+
+[182]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/server.js#L28-L38 "Source code on GitHub"
+
+[183]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/server.js#L49-L123 "Source code on GitHub"
+
+[184]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/server.js#L134-L208 "Source code on GitHub"
+
+[185]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/tiles.js#L15-L134 "Source code on GitHub"
+
+[186]: https://github.com/mapbox/hecate#vector-tiles
+
+[187]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/tiles.js#L28-L36 "Source code on GitHub"
+
+[188]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/tiles.js#L48-L133 "Source code on GitHub"
+
+[189]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/user.js#L15-L332 "Source code on GitHub"
+
+[190]: https://github.com/mapbox/hecate#user-options
+
+[191]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/user.js#L28-L39 "Source code on GitHub"
+
+[192]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/user.js#L50-L133 "Source code on GitHub"
+
+[193]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/user.js#L143-L216 "Source code on GitHub"
+
+[194]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/user.js#L229-L331 "Source code on GitHub"
+
+[195]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/webhooks.js#L15-L575 "Source code on GitHub"
+
+[196]: https://github.com/mapbox/hecate#webhooks
+
+[197]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/webhooks.js#L28-L41 "Source code on GitHub"
+
+[198]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/webhooks.js#L52-L128 "Source code on GitHub"
+
+[199]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/webhooks.js#L140-L226 "Source code on GitHub"
+
+[200]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/webhooks.js#L238-L323 "Source code on GitHub"
+
+[201]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/webhooks.js#L338-L453 "Source code on GitHub"
+
+[202]: https://github.com/mapbox/HecateJS/blob/81c47f2108c6608e042f3299046afc31ca0e9e08/lib/webhooks.js#L467-L574 "Source code on GitHub"

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -15,6 +15,11 @@ class Auth {
         this.api = api;
     }
 
+    /**
+     * Print help documentation about the subcommand to stderr
+     *
+     * @returns {undefined}
+     */
     help() {
         console.error();
         console.error('Fetch authentication settings that the server uses to allow or deny specific api endpoints');
@@ -32,6 +37,8 @@ class Auth {
      * @param {!Object} options Options for making a request to the auth API
      *
      * @param {function} cb (err, res) style callback function
+     *
+     * @return {function} callback
      */
     get(options = {}, cb) {
         const self = this;

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -11,14 +11,17 @@ const request = require('request');
  * @see {@link https://github.com/mapbox/hecate#authentication|Hecate Documentation}
  */
 class Auth {
+    /**
+     * Create a new Auth Instance
+     *
+     * @param {Hecate} api parent hecate instance
+     */
     constructor(api) {
         this.api = api;
     }
 
     /**
      * Print help documentation about the subcommand to stderr
-     *
-     * @returns {undefined}
      */
     help() {
         console.error();
@@ -35,10 +38,7 @@ class Auth {
      * Return the auth settings for a given hecate instance
      *
      * @param {!Object} options Options for making a request to the auth API
-     *
      * @param {function} cb (err, res) style callback function
-     *
-     * @return {function} callback
      */
     get(options = {}, cb) {
         const self = this;
@@ -47,14 +47,18 @@ class Auth {
 
         if (options.script) {
             cb = cli;
-            return main();
+            main();
         } else if (options.cli) {
             cb = cli;
-            return main();
+            main();
         } else {
-            return main();
+            main();
         }
 
+        /**
+         * Once the options object is populated, make the API request
+         * @private
+         */
         function main() {
             request.get({
                 json: true,
@@ -67,14 +71,23 @@ class Auth {
                 if (res.statusCode === 401) return cb(new Error('401: Unauthorized'));
                 if (res.statusCode !== 200) return cb(new Error(JSON.stringify(res.body)));
 
-                return cb(null, res.body);
+                cb(null, res.body);
             });
         }
 
-        function cli(err, res) {
+        /**
+         * If in CLI mode, write results to stdout
+         * or throw any errors incurred
+         *
+         * @private
+         *
+         * @param {Error} err [optional] API Error
+         * @param {Object} auth Hecate Auth JSON
+         */
+        function cli(err, auth) {
             if (err) throw err;
 
-            console.log(JSON.stringify(res, null, 4));
+            console.log(JSON.stringify(auth, null, 4));
         }
     }
 }

--- a/lib/bbox.js
+++ b/lib/bbox.js
@@ -15,14 +15,17 @@ const EOT = require('../util/eot');
  * @see {@link https://github.com/mapbox/hecate#downloading-multiple-features-via-bbox|Hecate Documentation}
  */
 class BBox {
+    /**
+     * Create a new BBOX Instance
+     *
+     * @param {Hecate} api parent hecate instance
+     */
     constructor(api) {
         this.api = api;
     }
 
     /**
      * Print help documentation about the subcommand to stderr
-     *
-     * @returns {undefined}
      */
     help() {
         console.error();
@@ -46,6 +49,8 @@ class BBox {
      * @param {Stream} [options.output] Stream to write line-delimited GeoJSON to
      *
      * @param {function} cb (err, res) style callback function
+     *
+     * @return {function} (err, res) style callback
      */
     get(options = {}, cb) {
         const self = this;
@@ -104,6 +109,12 @@ class BBox {
             return main();
         }
 
+        /**
+         * Once the options object is populated, make the API request
+         * @private
+         *
+         * @returns {undefined}
+         */
         function main() {
             if (!options.bbox) return cb(new Error('options.bbox required'));
             if (!options.output) return cb(new Error('options.output required'));
@@ -130,6 +141,16 @@ class BBox {
             }).pipe(new EOT(cb)).pipe(options.output);
         }
 
+        /**
+         * If in CLI mode, write results to stdout
+         * or throw any errors incurred
+         *
+         * @private
+         *
+         * @param {Error} err [optional] API Error
+         *
+         * @returns {undefined}
+         */
         function cli(err) {
             if (err) throw err;
         }

--- a/lib/bbox.js
+++ b/lib/bbox.js
@@ -19,6 +19,11 @@ class BBox {
         this.api = api;
     }
 
+    /**
+     * Print help documentation about the subcommand to stderr
+     *
+     * @returns {undefined}
+     */
     help() {
         console.error();
         console.error('Fetch raw data from the server using the bbox API');

--- a/lib/bounds.js
+++ b/lib/bounds.js
@@ -14,14 +14,17 @@ const EOT = require('../util/eot');
  * @see {@link https://github.com/mapbox/hecate#boundaries|Hecate Documentation}
  */
 class Bounds {
+    /**
+     * Create a new Bounds Instance
+     *
+     * @param {Hecate} api parent hecate instance
+     */
     constructor(api) {
         this.api = api;
     }
 
     /**
      * Print help documentation about the subcommand to stderr
-     *
-     * @returns {undefined}
      */
     help() {
         console.error();
@@ -43,8 +46,9 @@ class Bounds {
      * Return stats of geo data within a give bounds
      *
      * @param {!Object} options options for makign a query to the bounds list endpoint
-     *
      * @param {function} cb (err, res) style callback function
+     *
+     * @return {function} (err, res) style callback
      */
     stats(options = {}, cb) {
         const self = this;
@@ -94,6 +98,12 @@ class Bounds {
             return main();
         }
 
+        /**
+         * Once the options object is populated, make the API request
+         * @private
+         *
+         * @returns {undefined}
+         */
         function main() {
             if (!options.bound) return cb(new Error('options.bound required'));
 
@@ -110,10 +120,21 @@ class Bounds {
             });
         }
 
-        function cli(err, res) {
+        /**
+         * If in CLI mode, write results to stdout
+         * or throw any errors incurred
+         *
+         * @private
+         *
+         * @param {Error} err [optional] API Error
+         * @param {Object} stats stats object
+         *
+         * @returns {undefined}
+         */
+        function cli(err, stats) {
             if (err) throw err;
 
-            console.log(JSON.stringify(res, null, 4));
+            console.log(JSON.stringify(stats, null, 4));
         }
     }
 
@@ -121,8 +142,9 @@ class Bounds {
      * Return a list of the bounds that are currently loaded on the server
      *
      * @param {!Object} options options for makign a query to the bounds list endpoint
-     *
      * @param {function} cb (err, res) style callback function
+     *
+     * @return {function} (err, res) style callback
      */
     list(options = {}, cb) {
         const self = this;
@@ -164,6 +186,12 @@ class Bounds {
             return main();
         }
 
+        /**
+         * Once the options object is populated, make the API request
+         * @private
+         *
+         * @returns {undefined}
+         */
         function main() {
             request({
                 method: 'GET',
@@ -178,10 +206,21 @@ class Bounds {
             });
         }
 
-        function cli(err, res) {
+        /**
+         * If in CLI mode, write results to stdout
+         * or throw any errors incurred
+         *
+         * @private
+         *
+         * @param {Error} err [optional] API Error
+         * @param {Object} bounds list of bounds
+         *
+         * @returns {undefined}
+         */
+        function cli(err, bounds) {
             if (err) throw err;
 
-            console.log(JSON.stringify(res, null, 4));
+            console.log(JSON.stringify(bounds, null, 4));
         }
     }
 
@@ -192,8 +231,9 @@ class Bounds {
      * @param {!Object} options Options for making a request to the bounds endpoint
      * @param {String} [options.bound] Name of the bound to download from
      * @param {Stream} [options.output] Stream to write line-delimited GeoJSON to
-     *
      * @param {function} cb (err, res) style callback function
+     *
+     * @return {function} (err, res) style callback
      */
     get(options = {}, cb) {
         const self = this;
@@ -247,6 +287,12 @@ class Bounds {
             return main();
         }
 
+        /**
+         * Once the options object is populated, make the API request
+         * @private
+         *
+         * @returns {undefined}
+         */
         function main() {
             if (!options.bound) return cb(new Error('options.bound required'));
             if (!options.output) return cb(new Error('options.output required'));
@@ -262,6 +308,16 @@ class Bounds {
             }).pipe(new EOT(cb)).pipe(options.output);
         }
 
+        /**
+         * If in CLI mode, write results to stdout
+         * or throw any errors incurred
+         *
+         * @private
+         *
+         * @param {Error} err [optional] API Error
+         *
+         * @returns {undefined}
+         */
         function cli(err) {
             if (err) throw err;
         }
@@ -272,8 +328,9 @@ class Bounds {
      *
      * @param {!Object} options Options for making a request to the bounds endpoint
      * @param {String} [options.bound] Name of the bound to download from
-     *
      * @param {function} cb (err, res) style callback function
+     *
+     * @return {function} (err, res) style callback
      */
     meta(options = {}, cb) {
         const self = this;
@@ -326,6 +383,12 @@ class Bounds {
             return main();
         }
 
+        /**
+         * Once the options object is populated, make the API request
+         * @private
+         *
+         * @returns {undefined}
+         */
         function main() {
             if (!options.bound) return cb(new Error('options.bound required'));
 
@@ -341,10 +404,21 @@ class Bounds {
             });
         }
 
-        function cli(err, res) {
+        /**
+         * If in CLI mode, write results to stdout
+         * or throw any errors incurred
+         *
+         * @private
+         *
+         * @param {Error} err [optional] API Error
+         * @param {Object} meta meta data about a given bound
+         *
+         * @returns {undefined}
+         */
+        function cli(err, meta) {
             if (err) throw err;
 
-            console.log(JSON.stringify(res, null, 4));
+            console.log(JSON.stringify(meta, null, 4));
         }
     }
 
@@ -353,8 +427,9 @@ class Bounds {
      *
      * @param {!Object} options Options for making a request to the bounds endpoint
      * @param {String} [options.bound] Name of the bound to download from
-     *
      * @param {function} cb (err, res) style callback function
+     *
+     * @return {function} (err, res) style callback
      */
     delete(options = {}, cb) {
         const self = this;
@@ -404,6 +479,12 @@ class Bounds {
             return main();
         }
 
+        /**
+         * Once the options object is populated, make the API request
+         * @private
+         *
+         * @returns {undefined}
+         */
         function main() {
             if (!options.bound) return cb(new Error('options.bound required'));
 
@@ -419,6 +500,16 @@ class Bounds {
             });
         }
 
+        /**
+         * If in CLI mode, write results to stdout
+         * or throw any errors incurred
+         *
+         * @private
+         *
+         * @param {Error} err [optional] API Error
+         *
+         * @returns {undefined}
+         */
         function cli(err) {
             if (err) throw err;
 
@@ -432,8 +523,9 @@ class Bounds {
      * @param {!Object} options Options for making a request to the bounds endpoint
      * @param {String} [options.bound] Name of the bound to download from
      * @param {String} [options.geom] JSON Geometry of bound
-     *
      * @param {function} cb (err, res) style callback function
+     *
+     * @return {function} (err, res) style callback
      */
     set(options = {}, cb) {
         const self = this;
@@ -490,6 +582,12 @@ class Bounds {
             return main();
         }
 
+        /**
+         * Once the options object is populated, make the API request
+         * @private
+         *
+         * @returns {undefined}
+         */
         function main() {
             if (!options.bound) return cb(new Error('options.bound required'));
             if (!options.geometry) return cb(new Error('options.geometry required'));
@@ -512,6 +610,16 @@ class Bounds {
             });
         }
 
+        /**
+         * If in CLI mode, write results to stdout
+         * or throw any errors incurred
+         *
+         * @private
+         *
+         * @param {Error} err [optional] API Error
+         *
+         * @returns {undefined}
+         */
         function cli(err) {
             if (err) throw err;
 

--- a/lib/bounds.js
+++ b/lib/bounds.js
@@ -45,7 +45,7 @@ class Bounds {
     /**
      * Return stats of geo data within a give bounds
      *
-     * @param {!Object} options options for makign a query to the bounds list endpoint
+     * @param {!Object} options options for making a query to the bounds list endpoint
      * @param {function} cb (err, res) style callback function
      *
      * @return {function} (err, res) style callback
@@ -141,7 +141,7 @@ class Bounds {
     /**
      * Return a list of the bounds that are currently loaded on the server
      *
-     * @param {!Object} options options for makign a query to the bounds list endpoint
+     * @param {!Object} options options for making a query to the bounds list endpoint
      * @param {function} cb (err, res) style callback function
      *
      * @return {function} (err, res) style callback

--- a/lib/bounds.js
+++ b/lib/bounds.js
@@ -18,6 +18,11 @@ class Bounds {
         this.api = api;
     }
 
+    /**
+     * Print help documentation about the subcommand to stderr
+     *
+     * @returns {undefined}
+     */
     help() {
         console.error();
         console.error('Fetch raw data from the server using the bounds API');

--- a/lib/bounds.js
+++ b/lib/bounds.js
@@ -74,7 +74,7 @@ class Bounds {
                 default: options.bound
             }];
 
-            if (!self.api.user && self.api.auth_rules && self.api.auth_rules.stats.bounds !== 'public') {
+            if (!self.api.user && self.api.auth_rules && self.api.auth_rules.stats.get !== 'public') {
                 args = args.concat(auth(self.api.user));
             }
 

--- a/lib/clone.js
+++ b/lib/clone.js
@@ -14,14 +14,17 @@ const EOT = require('../util/eot');
  * @see {@link https://github.com/mapbox/hecate#downloading-via-clone|Hecate Documentation}
  */
 class Clone {
+    /**
+     * Create a new Clone Instance
+     *
+     * @param {Hecate} api parent hecate instance
+     */
     constructor(api) {
         this.api = api;
     }
 
     /**
      * Print help documentation about the subcommand to stderr
-     *
-     * @returns {undefined}
      */
     help() {
         console.error();
@@ -39,8 +42,9 @@ class Clone {
      *
      * @param {!Object} options Options for making a request to the hecate /api/data/features endpoint
      * @param {Stream} [options.output] Stream to write line-delimited GeoJSON to
-     *
      * @param {function} cb (err, res) style callback function
+     *
+     * @return {function} (err, res) style callback
      */
     get(options = {}, cb) {
         const self = this;
@@ -85,6 +89,12 @@ class Clone {
             return main();
         }
 
+        /**
+         * Once the options object is populated, make the API request
+         * @private
+         *
+         * @returns {undefined}
+         */
         function main() {
             if (!options.output) return cb(new Error('options.output required'));
 
@@ -99,6 +109,16 @@ class Clone {
             }).pipe(new EOT(cb)).pipe(options.output);
         }
 
+        /**
+         * If in CLI mode, write results to stdout
+         * or throw any errors incurred
+         *
+         * @private
+         *
+         * @param {Error} err [optional] API Error
+         *
+         * @returns {undefined}
+         */
         function cli(err) {
             if (err) throw err;
         }

--- a/lib/clone.js
+++ b/lib/clone.js
@@ -18,6 +18,11 @@ class Clone {
         this.api = api;
     }
 
+    /**
+     * Print help documentation about the subcommand to stderr
+     *
+     * @returns {undefined}
+     */
     help() {
         console.error();
         console.error('Fetch a complete dataset from the server');

--- a/lib/deltas.js
+++ b/lib/deltas.js
@@ -13,14 +13,17 @@ const auth = require('../util/get_auth');
  * @see {@link https://github.com/mapbox/api-geocoder/pull/2634#issuecomment-481255528|Hecate Documentation}
  */
 class Deltas {
+    /**
+     * Create a new Deltas Instance
+     *
+     * @param {Hecate} api parent hecate instance
+     */
     constructor(api) {
         this.api = api;
     }
 
     /**
      * Print help documentation about the subcommand to stderr
-     *
-     * @returns {undefined}
      */
     help() {
         console.error();
@@ -39,8 +42,9 @@ class Deltas {
      * @param {!Object} options Options for making a request to the deltas endpoint
      * @param {String} [options.limit=100] Number of deltas to list by default
      * @param {String} [options.offset] delta id to start listing at
-     *
      * @param {function} cb (err, res) style callback function
+     *
+     * @return {function} (err, res) style callback
      */
     list(options = {}, cb) {
         const self = this;
@@ -98,6 +102,12 @@ class Deltas {
             return main();
         }
 
+        /**
+         * Once the options object is populated, make the API request
+         * @private
+         *
+         * @returns {undefined}
+         */
         function main() {
             if (!options.limit) options.limit = 100;
             const query = options.offset ?
@@ -116,10 +126,21 @@ class Deltas {
             });
         }
 
-        function cli(err, res) {
+        /**
+         * If in CLI mode, write results to stdout
+         * or throw any errors incurred
+         *
+         * @private
+         *
+         * @param {Error} err [optional] API Error
+         * @param {Object} deltas list of deltas
+         *
+         * @returns {undefined}
+         */
+        function cli(err, deltas) {
             if (err) throw err;
 
-            console.log(JSON.stringify(res, null, 4));
+            console.log(JSON.stringify(deltas, null, 4));
         }
     }
 
@@ -127,8 +148,9 @@ class Deltas {
      * Returns data about a specific delta
      *
      * @param {!Object} options Options for making a request to the deltas endpoint
-     *
      * @param {function} cb (err, res) style callback function
+     *
+     * @return {function} (err, res) style callback
      */
     get(options = {}, cb) {
         const self = this;
@@ -178,6 +200,12 @@ class Deltas {
             return main();
         }
 
+        /**
+         * Once the options object is populated, make the API request
+         * @private
+         *
+         * @returns {undefined}
+         */
         function main() {
             if (!options.delta) return cb(new Error('options.delta required'));
 
@@ -194,10 +222,21 @@ class Deltas {
             });
         }
 
-        function cli(err, res) {
+        /**
+         * If in CLI mode, write results to stdout
+         * or throw any errors incurred
+         *
+         * @private
+         *
+         * @param {Error} err [optional] API Error
+         * @param {Object} delta delta object
+         *
+         * @returns {undefined}
+         */
+        function cli(err, delta) {
             if (err) throw err;
 
-            console.log(JSON.stringify(res, null, 4));
+            console.log(JSON.stringify(delta, null, 4));
         }
     }
 }

--- a/lib/deltas.js
+++ b/lib/deltas.js
@@ -17,6 +17,11 @@ class Deltas {
         this.api = api;
     }
 
+    /**
+     * Print help documentation about the subcommand to stderr
+     *
+     * @returns {undefined}
+     */
     help() {
         console.error();
         console.error('Fetch a list of deltas or information about a single delta');

--- a/lib/feature.js
+++ b/lib/feature.js
@@ -17,6 +17,11 @@ class Feature {
         this.api = api;
     }
 
+    /** 
+     * Print help documentation about the subcommand to stderr
+     *
+     * @returns {undefined}
+     */
     help() {
         console.error();
         console.error('Fetch an individual feature and it\'s corresponding metadata');

--- a/lib/feature.js
+++ b/lib/feature.js
@@ -13,14 +13,17 @@ const auth = require('../util/get_auth');
  * @see {@link https://github.com/mapbox/hecate#downloading-individual-features|Hecate Documentation}
  */
 class Feature {
+    /**
+     * Create a new Feature Instance
+     *
+     * @param {Hecate} api parent hecate instance
+     */
     constructor(api) {
         this.api = api;
     }
 
-    /** 
+    /**
      * Print help documentation about the subcommand to stderr
-     *
-     * @returns {undefined}
      */
     help() {
         console.error();
@@ -40,8 +43,9 @@ class Feature {
      *
      * @param {!Object} options Options for making a request to the bounds endpoint
      * @param {String} [options.feature] ID of the feature to download from
-     *
      * @param {function} cb (err, res) style callback function
+     *
+     * @return {function} (err, res) style callback
      */
     history(options = {}, cb) {
         const self = this;
@@ -91,6 +95,12 @@ class Feature {
             return main();
         }
 
+        /**
+         * Once the options object is populated, make the API request
+         * @private
+         *
+         * @returns {undefined}
+         */
         function main() {
             if (!options.feature) return cb(new Error('options.feature required'));
 
@@ -107,10 +117,21 @@ class Feature {
             });
         }
 
-        function cli(err, res) {
+        /**
+         * If in CLI mode, write results to stdout
+         * or throw any errors incurred
+         *
+         * @private
+         *
+         * @param {Error} err [optional] API Error
+         * @param {Object} history history of the feature
+         *
+         * @returns {undefined}
+         */
+        function cli(err, history) {
             if (err) throw err;
 
-            console.log(JSON.stringify(res, null, 4));
+            console.log(JSON.stringify(history, null, 4));
         }
     }
 
@@ -120,8 +141,9 @@ class Feature {
      *
      * @param {!Object} options Options for making a request to the bounds endpoint
      * @param {String} [options.feature] key of the feature to download from
-     *
      * @param {function} cb (err, res) style callback function
+     *
+     * @return {function} (err, res) style callback
      */
     key(options = {}, cb) {
         const self = this;
@@ -171,6 +193,12 @@ class Feature {
             return main();
         }
 
+        /**
+         * Once the options object is populated, make the API request
+         * @private
+         *
+         * @returns {undefined}
+         */
         function main() {
             if (!options.feature) return cb(new Error('options.feature required'));
 
@@ -187,10 +215,21 @@ class Feature {
             });
         }
 
-        function cli(err, res) {
+        /**
+         * If in CLI mode, write results to stdout
+         * or throw any errors incurred
+         *
+         * @private
+         *
+         * @param {Error} err [optional] API Error
+         * @param {Object} feature requested feature
+         *
+         * @returns {undefined}
+         */
+        function cli(err, feature) {
             if (err) throw err;
 
-            console.log(JSON.stringify(res, null, 4));
+            console.log(JSON.stringify(feature, null, 4));
         }
     }
 
@@ -200,8 +239,9 @@ class Feature {
      *
      * @param {!Object} options Options for making a request to the bounds endpoint
      * @param {String} [options.feature] ID of the feature to download from
-     *
      * @param {function} cb (err, res) style callback function
+     *
+     * @return {function} (err, res) style callback
      */
     get(options = {}, cb) {
         const self = this;
@@ -251,6 +291,12 @@ class Feature {
             return main();
         }
 
+        /**
+         * Once the options object is populated, make the API request
+         * @private
+         *
+         * @returns {undefined}
+         */
         function main() {
             if (!options.feature) return cb(new Error('options.feature required'));
 
@@ -267,10 +313,21 @@ class Feature {
             });
         }
 
-        function cli(err, res) {
+        /**
+         * If in CLI mode, write results to stdout
+         * or throw any errors incurred
+         *
+         * @private
+         *
+         * @param {Error} err [optional] API Error
+         * @param {Object} feature requested feature
+         *
+         * @returns {undefined}
+         */
+        function cli(err, feature) {
             if (err) throw err;
 
-            console.log(JSON.stringify(res, null, 4));
+            console.log(JSON.stringify(feature, null, 4));
         }
     }
 }

--- a/lib/import.js
+++ b/lib/import.js
@@ -17,12 +17,28 @@ const auth = require('../util/get_auth');
 const request = require('requestretry');
 const Schema = require('../lib/schema.js');
 
+/**
+ * Allow features to be passed to the import API as an array
+ * instead of as a stream
+ *
+ * @class
+ */
 class ArrayReader {
+    /**
+     * Given an array of features to import, create a new ArrayReader
+     *
+     * @param {Object[]} array Array of features
+     */
     constructor(array) {
         this.array = array;
         this.counter = 0;
     }
 
+    /**
+     * Return the next feature in the array, mimics a stream
+     *
+     * @returns {string} GeoJSON Feature to import
+     */
     next() {
         let line = false;
         if (this.counter < this.array.length) {
@@ -42,14 +58,17 @@ class ArrayReader {
  * @see {@link https://github.com/mapbox/hecate#feature-creation|Hecate Documentation}
  */
 class Import {
+    /**
+     * Create a new Import Instance
+     *
+     * @param {Hecate} api parent hecate instance
+     */
     constructor(api) {
         this.api = api;
     }
 
-    /** 
+    /**
      * Print help documentation about the subcommand to stderr
-     *
-     * @returns {undefined}
      */
     help() {
         console.error();
@@ -66,6 +85,20 @@ class Import {
         console.error();
     }
 
+    /**
+     * Given a Stream of line-delimited features or an Array of features, validate and
+     * import them
+     *
+     * @param {Object} options options object
+     * @param {string} options.message Human readable description of changes
+     * @param {string|Object[]} options.input String of filepath or Array containing features to import
+     * @param {boolean} options.ignoreRHR Ignore RHR winding errors
+     * @param {boolean} options.ignoreDup Don't check duplicate IDs (will usually cause an import failure if they exist)
+     * @param {boolean} options.dryrun Perform all validation but don't import
+     * @param {function} cb (err, res) style callback
+     *
+     * @returns {function} (err, res) style callback
+     */
     multi(options = {}, cb) {
         const self = this;
 
@@ -122,6 +155,12 @@ class Import {
             return main();
         }
 
+        /**
+         * Once the options object is populated, make the API request
+         * @private
+         *
+         * @returns {undefined}
+         */
         function main() {
             if (!options.input) return cb(new Error('options.input required'));
             if (!options.message) return cb(new Error('options.message required'));
@@ -162,6 +201,14 @@ class Import {
                 });
             }
 
+            /**
+             * Read features from the stream, chunking into an acceptable
+             * import size, and passing to the import function
+             *
+             * @private
+             *
+             * @returns {undefined}
+             */
             function read() {
                 if (options.dryrun) {
                     console.error('ok - ok skipping import (dryrun)');
@@ -198,6 +245,14 @@ class Import {
                 });
             }
 
+            /**
+             * Once validated, perform an import of the given features
+             *
+             * @private
+             *
+             * @param {Object} body GeoJSON Feature collection to upload
+             * @param {function} upload_cb (err, res) style callback
+             */
             function upload(body, upload_cb) {
                 console.error(`ok - beginning upload of ${body.features.length} features`);
 
@@ -233,6 +288,16 @@ class Import {
             }
         }
 
+        /**
+         * If in CLI mode, write results to stdout
+         * or throw any errors incurred
+         *
+         * @private
+         *
+         * @param {Error} err [optional] API Error
+         *
+         * @returns {undefined}
+         */
         function cli(err) {
             if (err) throw err;
 

--- a/lib/import.js
+++ b/lib/import.js
@@ -46,6 +46,11 @@ class Import {
         this.api = api;
     }
 
+    /** 
+     * Print help documentation about the subcommand to stderr
+     *
+     * @returns {undefined}
+     */
     help() {
         console.error();
         console.error('Upload Create/Modified/Deleted Data to the server');

--- a/lib/revert.js
+++ b/lib/revert.js
@@ -12,6 +12,11 @@ class Revert {
         this.api = api;
     }
 
+    /** 
+     * Print help documentation about the subcommand to stderr
+     *
+     * @returns {undefined}
+     */
     help() {
         console.error();
         console.error('Revert data of an specified delta');
@@ -29,8 +34,8 @@ class Revert {
      * Revert a given set of deltas
      *
      * @param {!Object} options Options for making reversion of a set of deltas
-     * @param {Number} options.start Inclusive start delta ID to revert
-     * @param {Number} options.end Inclusive end delta ID to revert
+     * @param {number} options.start Inclusive start delta ID to revert
+     * @param {number} options.end Inclusive end delta ID to revert
      * @param {Stream} [options.output] Stream to write line-delimited GeoJSON to
      *
      * @param {function} cb (err, res) style callback function

--- a/lib/revert.js
+++ b/lib/revert.js
@@ -8,14 +8,17 @@ const revert = require('../util/revert');
  * @public
  */
 class Revert {
+    /**
+     * Create a new Revert Instance
+     *
+     * @param {Hecate} api parent hecate instance
+     */
     constructor(api) {
         this.api = api;
     }
 
-    /** 
+    /**
      * Print help documentation about the subcommand to stderr
-     *
-     * @returns {undefined}
      */
     help() {
         console.error();
@@ -39,6 +42,8 @@ class Revert {
      * @param {Stream} [options.output] Stream to write line-delimited GeoJSON to
      *
      * @param {function} cb (err, res) style callback function
+     *
+     * @returns {function} (err, res) style callback
      */
     deltas(options = {}, cb) {
         const self = this;
@@ -102,6 +107,17 @@ class Revert {
             return main(options);
         }
 
+        /**
+         * Once the options object is populated, make the API request
+         * @private
+         *
+         * @param {Object} options option object
+         * @param {number} options.start Inclusive start delta ID to revert
+         * @param {number} options.end Inclusive end delta ID to revert
+         * @param {Stream} [options.output] Stream to write line-delimited GeoJSON to
+         *
+         * @returns {undefined}
+         */
         async function main(options) {
             if (!options.start) return cb(new Error('start delta is required'));
             if (!options.end) return cb(new Error('start delta is required'));
@@ -122,6 +138,16 @@ class Revert {
             return cb();
         }
 
+        /**
+         * If in CLI mode, write results to stdout
+         * or throw any errors incurred
+         *
+         * @private
+         *
+         * @param {Error} err [optional] API Error
+         *
+         * @returns {undefined}
+         */
         function cli(err) {
             if (err) throw err;
 

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -17,6 +17,11 @@ class Schema {
         this.api = api;
     }
 
+    /** 
+     * Print help documentation about the subcommand to stderr
+     *
+     * @returns {undefined}
+     */
     help() {
         console.error();
         console.error('Fetch Schema (if any) that the server uses to validate features');

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -13,14 +13,17 @@ const auth = require('../util/get_auth');
  * @see {@link https://github.com/mapbox/hecate#schema|Hecate Documentation}
  */
 class Schema {
+    /**
+     * Create a new Schema Instance
+     *
+     * @param {Hecate} api parent hecate instance
+     */
     constructor(api) {
         this.api = api;
     }
 
-    /** 
+    /**
      * Print help documentation about the subcommand to stderr
-     *
-     * @returns {undefined}
      */
     help() {
         console.error();
@@ -33,6 +36,14 @@ class Schema {
         console.error();
     }
 
+    /**
+     * Retrieve a JSON schema that feature properties must conform to
+     *
+     * @param {Object} options options object
+     * @param {function} cb (err, res) style callback
+     *
+     * @returns {function} (err, res) style callback
+     */
     get(options = {}, cb) {
         const self = this;
         if (!options) options = {};
@@ -70,6 +81,12 @@ class Schema {
             return main();
         }
 
+        /**
+         * Once the options object is populated, make the API request
+         * @private
+         *
+         * @returns {undefined}
+         */
         function main() {
             request.get({
                 json: true,
@@ -86,11 +103,22 @@ class Schema {
             });
         }
 
-        function cli(err, res) {
+        /**
+         * If in CLI mode, write results to stdout
+         * or throw any errors incurred
+         *
+         * @private
+         *
+         * @param {Error} err [optional] API Error
+         * @param {Object} schema JSON Schema
+         *
+         * @returns {undefined}
+         */
+        function cli(err, schema) {
             if (err) throw err;
 
-            if (res) {
-                console.log(JSON.stringify(res, null, 4));
+            if (schema) {
+                console.log(JSON.stringify(schema, null, 4));
             } else {
                 console.error('No Schema Enforcement');
             }

--- a/lib/server.js
+++ b/lib/server.js
@@ -13,14 +13,17 @@ const auth = require('../util/get_auth');
  * @see {@link https://github.com/mapbox/hecate#meta|Hecate Documentation}
  */
 class Server {
+    /**
+     * Create a new Server Instance
+     *
+     * @param {Hecate} api parent hecate instance
+     */
     constructor(api) {
         this.api = api;
     }
 
-    /** 
+    /**
      * Print help documentation about the subcommand to stderr
-     *
-     * @returns {undefined}
      */
     help() {
         console.error();
@@ -40,6 +43,8 @@ class Server {
      * @param {!Object} options Options for making a request to meta API
      *
      * @param {function} cb (err, res) style callback function
+     *
+     * @returns {function} (err, res) style callback
      */
     get(options = {}, cb) {
         const self = this;
@@ -79,6 +84,12 @@ class Server {
             return main();
         }
 
+        /**
+         * Once the options object is populated, make the API request
+         * @private
+         *
+         * @returns {undefined}
+         */
         function main() {
             request({
                 json: true,
@@ -93,10 +104,21 @@ class Server {
             });
         }
 
-        function cli(err, res) {
+        /**
+         * If in CLI mode, write results to stdout
+         * or throw any errors incurred
+         *
+         * @private
+         *
+         * @param {Error} err [optional] API Error
+         * @param {Object} server server metadata
+         *
+         * @returns {undefined}
+         */
+        function cli(err, server) {
             if (err) throw err;
 
-            console.log(JSON.stringify(res, null, 4));
+            console.log(JSON.stringify(server, null, 4));
         }
     }
 
@@ -106,6 +128,8 @@ class Server {
      * @param {!Object} options Options for making a request to meta API
      *
      * @param {function} cb (err, res) style callback function
+     *
+     * @returns {function} (err, res) style callback
      */
     stats(options = {}, cb) {
         const self = this;
@@ -145,6 +169,12 @@ class Server {
             return main();
         }
 
+        /**
+         * Once the options object is populated, make the API request
+         * @private
+         *
+         * @returns {undefined}
+         */
         function main() {
             request({
                 json: true,
@@ -159,10 +189,21 @@ class Server {
             });
         }
 
-        function cli(err, res) {
+        /**
+         * If in CLI mode, write results to stdout
+         * or throw any errors incurred
+         *
+         * @private
+         *
+         * @param {Error} err [optional] API Error
+         * @param {Object} stats Server data stats
+         *
+         * @returns {undefined}
+         */
+        function cli(err, stats) {
             if (err) throw err;
 
-            console.log(JSON.stringify(res, null, 4));
+            console.log(JSON.stringify(stats, null, 4));
         }
     }
 }

--- a/lib/server.js
+++ b/lib/server.js
@@ -17,6 +17,11 @@ class Server {
         this.api = api;
     }
 
+    /** 
+     * Print help documentation about the subcommand to stderr
+     *
+     * @returns {undefined}
+     */
     help() {
         console.error();
         console.error('Fetch a metadata about the server');

--- a/lib/tiles.js
+++ b/lib/tiles.js
@@ -13,14 +13,17 @@ const auth = require('../util/get_auth');
  * @see {@link https://github.com/mapbox/hecate#vector-tiles|Hecate Documentation}
  */
 class Tiles {
+    /**
+     * Create a new Tiles Instance
+     *
+     * @param {Hecate} api parent hecate instance
+     */
     constructor(api) {
         this.api = api;
     }
 
-    /** 
+    /**
      * Print help documentation about the subcommand to stderr
-     *
-     * @returns {undefined}
      */
     help() {
         console.error();
@@ -39,6 +42,8 @@ class Tiles {
      * @param {String} [options.zxy] z/x/y coordinate to request
      *
      * @param {function} cb (err, res) style callback function
+     *
+     * @returns {function} (err, res) style callback
      */
     get(options = {}, cb) {
         const self = this;
@@ -88,6 +93,12 @@ class Tiles {
             return main();
         }
 
+        /**
+         * Once the options object is populated, make the API request
+         * @private
+         *
+         * @returns {undefined}
+         */
         function main() {
             if (!options.zxy) return cb(new Error('options.zxy required'));
 
@@ -104,6 +115,16 @@ class Tiles {
             });
         }
 
+        /**
+         * If in CLI mode, write results to stdout
+         * or throw any errors incurred
+         *
+         * @private
+         *
+         * @param {Error} err [optional] API Error
+         *
+         * @returns {undefined}
+         */
         function cli(err) {
             if (err) throw err;
 

--- a/lib/tiles.js
+++ b/lib/tiles.js
@@ -17,6 +17,11 @@ class Tiles {
         this.api = api;
     }
 
+    /** 
+     * Print help documentation about the subcommand to stderr
+     *
+     * @returns {undefined}
+     */
     help() {
         console.error();
         console.error('Fetch a Mapbox Vector Tile for the given zxy');

--- a/lib/user.js
+++ b/lib/user.js
@@ -13,14 +13,17 @@ const auth = require('../util/get_auth');
  * @see {@link https://github.com/mapbox/hecate#user-options|Hecate Documentation}
  */
 class User {
+    /**
+     * Create a new User Instance
+     *
+     * @param {Hecate} api parent hecate instance
+     */
     constructor(api) {
         this.api = api;
     }
 
-    /** 
+    /**
      * Print help documentation about the subcommand to stderr
-     *
-     * @returns {undefined}
      */
     help() {
         console.error();
@@ -35,6 +38,15 @@ class User {
         console.error();
     }
 
+    /**
+     * List users with optional filtering
+     *
+     * @param {Object} options Options object
+     * @param {string} options.filter User prefix to filter by
+     * @param {function} cb (err, res) style callback
+     *
+     * @returns {function} (err, res) style callback
+     */
     list(options = {}, cb) {
         const self = this;
 
@@ -81,6 +93,12 @@ class User {
             return main();
         }
 
+        /**
+         * Once the options object is populated, make the API request
+         * @private
+         *
+         * @returns {undefined}
+         */
         function main() {
             options.filter = options.filter ? encodeURIComponent(options.filter) : '';
 
@@ -96,13 +114,32 @@ class User {
             });
         }
 
-        function cli(err, res) {
+        /**
+         * If in CLI mode, write results to stdout
+         * or throw any errors incurred
+         *
+         * @private
+         *
+         * @param {Error} err [optional] API Error
+         * @param {Object} users list of users
+         *
+         * @returns {undefined}
+         */
+        function cli(err, users) {
             if (err) throw err;
 
-            console.log(JSON.stringify(res, null, 4));
+            console.log(JSON.stringify(users, null, 4));
         }
     }
 
+    /**
+     * Retrieve metadata about the user that makes the request
+     *
+     * @param {Object} options options object
+     * @param {function} cb (err, res) style callback
+     *
+     * @returns {function} (err, res) style callback
+     */
     info(options = {}, cb) {
         const self = this;
 
@@ -141,6 +178,12 @@ class User {
             return main();
         }
 
+        /**
+         * Once the options object is populated, make the API request
+         * @private
+         *
+         * @returns {undefined}
+         */
         function main() {
             request.get({
                 json: true,
@@ -154,13 +197,35 @@ class User {
             });
         }
 
-        function cli(err, res) {
+        /**
+         * If in CLI mode, write results to stdout
+         * or throw any errors incurred
+         *
+         * @private
+         *
+         * @param {Error} err [optional] API Error
+         * @param {Object} info user info
+         *
+         * @returns {undefined}
+         */
+        function cli(err, info) {
             if (err) throw err;
 
-            console.log(JSON.stringify(res, null, 4));
+            console.log(JSON.stringify(info, null, 4));
         }
     }
 
+    /**
+     * Register a new user account
+     *
+     * @param {Object} options options object
+     * @param {string} options.username Username to register
+     * @param {string} options.email Email of account to register
+     * @param {string} options.password Password of account to register
+     * @param {function} cb (err, res) style callback
+     *
+     * @returns {function} (err, res) style callback
+     */
     register(options = {}, cb) {
         const self = this;
 
@@ -222,6 +287,12 @@ class User {
             return main();
         }
 
+        /**
+         * Once the options object is populated, make the API request
+         * @private
+         *
+         * @returns {undefined}
+         */
         function main() {
             if (!options.username) return cb(new Error('options.username required'));
             if (!options.password) return cb(new Error('options.password required'));
@@ -242,6 +313,16 @@ class User {
             });
         }
 
+        /**
+         * If in CLI mode, write results to stdout
+         * or throw any errors incurred
+         *
+         * @private
+         *
+         * @param {Error} err [optional] API Error
+         *
+         * @returns {undefined}
+         */
         function cli(err) {
             if (err) throw err;
 

--- a/lib/user.js
+++ b/lib/user.js
@@ -17,6 +17,11 @@ class User {
         this.api = api;
     }
 
+    /** 
+     * Print help documentation about the subcommand to stderr
+     *
+     * @returns {undefined}
+     */
     help() {
         console.error();
         console.error('Manage user information');

--- a/lib/webhooks.js
+++ b/lib/webhooks.js
@@ -70,7 +70,7 @@ class Webhooks {
 
             let args = [];
 
-            if (!self.api.user && self.api.auth_rules && self.api.auth_rules.webhooks.list !== 'public') {
+            if (!self.api.user && self.api.auth_rules && self.api.auth_rules.webhooks.get !== 'public') {
                 args = args.concat(auth(self.api.user));
             }
 
@@ -164,7 +164,7 @@ class Webhooks {
                 default: options.id
             }];
 
-            if (!self.api.user && self.api.auth_rules && self.api.auth_rules.webhooks.list !== 'public') {
+            if (!self.api.user && self.api.auth_rules && self.api.auth_rules.webhooks.get !== 'public') {
                 args = args.concat(auth(self.api.user));
             }
 
@@ -262,7 +262,7 @@ class Webhooks {
                 default: options.id
             }];
 
-            if (!self.api.user && self.api.auth_rules && self.api.auth_rules.webhooks.delete !== 'public') {
+            if (!self.api.user && self.api.auth_rules && self.api.auth_rules.webhooks.set !== 'public') {
                 args = args.concat(auth(self.api.user));
             }
 
@@ -380,7 +380,7 @@ class Webhooks {
                 default: options.actions
             }];
 
-            if (!self.api.user && self.api.auth_rules && self.api.auth_rules.webhooks.update !== 'public') {
+            if (!self.api.user && self.api.auth_rules && self.api.auth_rules.webhooks.set !== 'public') {
                 args = args.concat(auth(self.api.user));
             }
 
@@ -503,7 +503,7 @@ class Webhooks {
                 default: options.actions
             }];
 
-            if (!self.api.user && self.api.auth_rules && self.api.auth_rules.webhooks.update !== 'public') {
+            if (!self.api.user && self.api.auth_rules && self.api.auth_rules.webhooks.set !== 'public') {
                 args = args.concat(auth(self.api.user));
             }
 

--- a/lib/webhooks.js
+++ b/lib/webhooks.js
@@ -13,14 +13,17 @@ const auth = require('../util/get_auth');
  * @see {@link https://github.com/mapbox/hecate#webhooks|Hecate Documentation}
  */
 class Webhooks {
+    /**
+     * Create a new Webhooks Instance
+     *
+     * @param {Hecate} api parent hecate instance
+     */
     constructor(api) {
         this.api = api;
     }
 
-    /** 
+    /**
      * Print help documentation about the subcommand to stderr
-     *
-     * @returns {undefined}
      */
     help() {
         console.error();
@@ -43,6 +46,8 @@ class Webhooks {
      * @param {!Object} options Options for making a request to the hecate /api/webhooks endpoint
      *
      * @param {function} cb (err, res) style callback function
+     *
+     * @returns {function} (err, res) style callback
      */
     list(options = {}, cb) {
         const self = this;
@@ -85,6 +90,12 @@ class Webhooks {
             return main();
         }
 
+        /**
+         * Once the options object is populated, make the API request
+         * @private
+         *
+         * @returns {undefined}
+         */
         function main() {
             request.get({
                 json: true,
@@ -98,6 +109,17 @@ class Webhooks {
             });
         }
 
+        /**
+         * If in CLI mode, write results to stdout
+         * or throw any errors incurred
+         *
+         * @private
+         *
+         * @param {Error} err [optional] API Error
+         * @param {Object} hooks list of webhooks
+         *
+         * @returns {undefined}
+         */
         function cli(err, hooks) {
             if (err) throw err;
 
@@ -112,6 +134,8 @@ class Webhooks {
      * @param {number} options.id ID of the webhook to retreive
      *
      * @param {function} cb (err, res) style callback function
+     *
+     * @returns {function} (err, res) style callback function
      */
     get(options = {}, cb) {
         const self = this;
@@ -162,6 +186,12 @@ class Webhooks {
             return main();
         }
 
+        /**
+         * Once the options object is populated, make the API request
+         * @private
+         *
+         * @returns {undefined}
+         */
         function main() {
             if (!options.id) return cb(new Error('options.id required'));
 
@@ -177,6 +207,17 @@ class Webhooks {
             });
         }
 
+        /**
+         * If in CLI mode, write results to stdout
+         * or throw any errors incurred
+         *
+         * @private
+         *
+         * @param {Error} err [optional] API Error
+         * @param {Object} hook single webhook
+         *
+         * @returns {undefined}
+         */
         function cli(err, hook) {
             if (err) throw err;
 
@@ -191,6 +232,8 @@ class Webhooks {
      * @param {number} options.id ID of the webhook to delete
      *
      * @param {function} cb (err, res) style callback function
+     *
+     * @returns {function} (err, res) style callback function
      */
     delete(options = {}, cb) {
         const self = this;
@@ -241,6 +284,12 @@ class Webhooks {
             return main();
         }
 
+        /**
+         * Once the options object is populated, make the API request
+         * @private
+         *
+         * @returns {undefined}
+         */
         function main() {
             if (!options.id) return cb(new Error('options.id required'));
 
@@ -256,6 +305,16 @@ class Webhooks {
             });
         }
 
+        /**
+         * If in CLI mode, write results to stdout
+         * or throw any errors incurred
+         *
+         * @private
+         *
+         * @param {Error} err [optional] API Error
+         *
+         * @returns {undefined}
+         */
         function cli(err) {
             if (err) throw err;
 
@@ -273,6 +332,8 @@ class Webhooks {
      * @param {Array<string>} options.actions server actions the webhook should be fired on
      *
      * @param {function} cb (err, res) style callback function
+     *
+     * @returns {function} (err, res) style callback function
      */
     update(options = {}, cb) {
         const self = this;
@@ -344,6 +405,12 @@ class Webhooks {
             return main();
         }
 
+        /**
+         * Once the options object is populated, make the API request
+         * @private
+         *
+         * @returns {undefined}
+         */
         function main() {
             if (!options.id) return cb(new Error('options.id required'));
             if (!options.name) return cb(new Error('options.name required'));
@@ -368,6 +435,16 @@ class Webhooks {
             });
         }
 
+        /**
+         * If in CLI mode, write results to stdout
+         * or throw any errors incurred
+         *
+         * @private
+         *
+         * @param {Error} err [optional] API Error
+         *
+         * @returns {undefined}
+         */
         function cli(err) {
             if (err) throw err;
 
@@ -384,6 +461,8 @@ class Webhooks {
      * @param {Array<string>} options.actions server actions the webhook should be fired on
      *
      * @param {function} cb (err, res) style callback function
+     *
+     * @returns {function} (err, res) style callback function
      */
     create(options = {}, cb) {
         const self = this;
@@ -448,6 +527,12 @@ class Webhooks {
             return main();
         }
 
+        /**
+         * Once the options object is populated, make the API request
+         * @private
+         *
+         * @returns {undefined}
+         */
         function main() {
             if (!options.name) return cb(new Error('options.name required'));
             if (!options.url) return cb(new Error('options.url required'));
@@ -471,6 +556,16 @@ class Webhooks {
             });
         }
 
+        /**
+         * If in CLI mode, write results to stdout
+         * or throw any errors incurred
+         *
+         * @private
+         *
+         * @param {Error} err [optional] API Error
+         *
+         * @returns {undefined}
+         */
         function cli(err) {
             if (err) throw err;
 

--- a/lib/webhooks.js
+++ b/lib/webhooks.js
@@ -17,6 +17,11 @@ class Webhooks {
         this.api = api;
     }
 
+    /** 
+     * Print help documentation about the subcommand to stderr
+     *
+     * @returns {undefined}
+     */
     help() {
         console.error();
         console.error('List, Create, Manage & Delete hecate webhooks');
@@ -104,7 +109,7 @@ class Webhooks {
      * Get a specific webhook given the ID
      *
      * @param {!Object} options Options for making a request to the hecate /api/webhooks endpoint
-     * @param {Number} options.id ID of the webhook to retreive
+     * @param {number} options.id ID of the webhook to retreive
      *
      * @param {function} cb (err, res) style callback function
      */
@@ -183,7 +188,7 @@ class Webhooks {
      * Delete a specific webhook given the ID
      *
      * @param {!Object} options Options for making a request to the hecate /api/webhooks endpoint
-     * @param {Number} options.id ID of the webhook to delete
+     * @param {number} options.id ID of the webhook to delete
      *
      * @param {function} cb (err, res) style callback function
      */
@@ -262,10 +267,10 @@ class Webhooks {
      * Update a given webhook ID
      *
      * @param {!Object} options Options for making a request to the hecate /api/webhooks endpoint
-     * @param {Number} options.id ID of the webhook to update
-     * @param {String} options.name Name of the webhook
-     * @param {String} options.url URL of the webhook
-     * @param {Array<String>} options.actions server actions the webhook should be fired on
+     * @param {number} options.id ID of the webhook to update
+     * @param {string} options.name Name of the webhook
+     * @param {string} options.url URL of the webhook
+     * @param {Array<string>} options.actions server actions the webhook should be fired on
      *
      * @param {function} cb (err, res) style callback function
      */
@@ -374,9 +379,9 @@ class Webhooks {
      * Create a new webhook
      *
      * @param {!Object} options Options for making a request to the hecate /api/webhooks endpoint
-     * @param {String} options.name Name of the webhook
-     * @param {String} options.url URL of the webhook
-     * @param {Array<String>} options.actions server actions the webhook should be fired on
+     * @param {string} options.name Name of the webhook
+     * @param {string} options.url URL of the webhook
+     * @param {Array<string>} options.actions server actions the webhook should be fired on
      *
      * @param {function} cb (err, res) style callback function
      */

--- a/package.json
+++ b/package.json
@@ -34,16 +34,13 @@
     "requestretry": "^4.0.0",
     "split": "^1.0.1"
   },
-  "eslintConfig": {
-    "extends": "@mapbox/eslint-config-geocoding"
-  },
   "engines": {
     "node": ">=10"
   },
   "scripts": {
-    "doc": "$(yarn bin)/documentation build --github --format md --output docs/api.md cli.js lib/**",
+    "doc": "documentation build --github --format md --output docs/api.md cli.js lib/**",
     "test": "yarn lint && tape test/*.test.js",
     "coverage": "TESTING=true nyc tape 'test/**/*.js' && nyc report --reporter=text-lcov > coverage.lcov && codecov",
-    "lint": "eslint cli.js lib/*.js util/*.js test/*.js"
+    "lint": "documentation lint cli.js lib/** && eslint cli.js lib/*.js util/*.js test/*.js"
   }
 }

--- a/test/util.validateBbox.test.js
+++ b/test/util.validateBbox.test.js
@@ -3,7 +3,11 @@
 const tape = require('tape');
 const validateBbox = require('../util/validateBbox.js');
 
-// From MDN guide to regexp: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
+/**
+ * From MDN guide to regexp: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
+ * @param {string} string regex string to escape
+ * @return {string} escaped string
+ */
 function escapeRegExp(string) {
     return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }

--- a/util/eot.js
+++ b/util/eot.js
@@ -8,6 +8,7 @@ const Transform = require('stream').Transform;
  * character was present to ensure all data was obtained
  *
  * @class
+ * @private
  */
 class EOT extends Transform {
     /**

--- a/util/eot.js
+++ b/util/eot.js
@@ -2,7 +2,19 @@
 
 const Transform = require('stream').Transform;
 
+/**
+ * Transform stream to passthrough linedelimited GeoJSON
+ * and upon termination of the stream, ensure EOT
+ * character was present to ensure all data was obtained
+ *
+ * @class
+ */
 class EOT extends Transform {
+    /**
+     * Construct a new EOT Instance
+     *
+     * @param {function} cb (err, res) style callback
+     */
     constructor(cb) {
         if (!cb) throw new Error('callback required');
 
@@ -14,7 +26,17 @@ class EOT extends Transform {
         Transform.call(this);
     }
 
-    _transform(chunk, env, done) {
+    /**
+     * Internal transform function to passthrough data
+     * and look for EOT character
+     *
+     * @param {Buffer} chunk chunk to passthrough
+     * @param {string} encoding The encoding of the chunk
+     * @param {function} done completion callback
+     *
+     * @returns {function} callback function
+     */
+    _transform(chunk, encoding, done) {
         if (chunk.indexOf('\u0004') === chunk.length - 1) {
             this.eot = true;
 
@@ -27,6 +49,13 @@ class EOT extends Transform {
         return done();
     }
 
+    /**
+     * Ensure the stream completeled successfully, checking for the EOT character
+     *
+     * @param {function} done completion callback
+     *
+     * @returns {function} (err, res) style callback
+     */
     _final(done) {
         if (!this.eot) return this.cb(new Error('Download Stream Terminated Abruptly - No EOT'));
 

--- a/util/revert.js
+++ b/util/revert.js
@@ -147,7 +147,9 @@ function iterate(db, stream) {
  * @param {number} options.start Delta Start ID
  * @param {number} options.end Delta End ID
  *
- * @returns {Promise}
+ * @param {Hecate} api Hecate Instance for API calls
+ *
+ * @returns {Promise} Promise containing db instance or error
  */
 function cache(options, api) {
     return new Promise((resolve, reject) => {
@@ -163,6 +165,15 @@ function cache(options, api) {
 
         deltai(options.start - 1);
 
+        /**
+         * Retrieve a single delta at a time, and then
+         * each of it's component feature histories in parallem
+         * commiting each to the database
+         *
+         * @param {number} i delta ID last retrieved
+         *
+         * @return {undefined}
+         */
         async function deltai(i) {
             if (i < options.end) {
                 i++;
@@ -227,6 +238,13 @@ function createCache() {
     return db;
 }
 
+/**
+ * Given a sqlite instance, close and delete it
+ *
+ * @param {Object} db sqlite3 database instance
+ *
+ * @returns {undefined}
+ */
 function cleanCache(db) {
     const name = db.name;
 

--- a/util/revert.js
+++ b/util/revert.js
@@ -42,6 +42,8 @@ const fs = require('fs');
  * See the Hecate docs for more information about feature actions
  * and versioning
  *
+ * @private
+ *
  * @param {Object[]} history Array of features accross all verisons of the feature
  * @param {number} version feature version that should be rolled back
  *
@@ -115,6 +117,8 @@ function inverse(history, version) {
  *
  * Writes inversion to given writable stream
  *
+ * @private
+ *
  * @param {Object} db sqlite3 db to iterate over
  * @param {Stream} stream output stream to write inverted features to
  */
@@ -142,6 +146,8 @@ function iterate(db, stream) {
  * Given a start/end range for a set of deltas, download
  * each of the deltas, then iterate through each feature,
  * retreiving it's history and writing it to disk
+ * 
+ * @private
  *
  * @param {Object} options options object
  * @param {number} options.start Delta Start ID
@@ -169,6 +175,8 @@ function cache(options, api) {
          * Retrieve a single delta at a time, and then
          * each of it's component feature histories in parallem
          * commiting each to the database
+         *
+         * @private
          *
          * @param {number} i delta ID last retrieved
          *
@@ -222,6 +230,8 @@ function cache(options, api) {
  * Create a new reversion sqlite3 database, initialize it with table
  * definitions, and pass back db object to caller
  *
+ * @private
+ *
  * @returns {Object} Sqlite3 Database Handler
  */
 function createCache() {
@@ -240,6 +250,8 @@ function createCache() {
 
 /**
  * Given a sqlite instance, close and delete it
+ *
+ * @private
  *
  * @param {Object} db sqlite3 database instance
  *

--- a/util/revert.js
+++ b/util/revert.js
@@ -42,8 +42,8 @@ const fs = require('fs');
  * See the Hecate docs for more information about feature actions
  * and versioning
  *
- * @param {Array[Object]} history Array of features accross all verisons of the feature
- * @param {Number} version feature version that should be rolled back
+ * @param {Object[]} history Array of features accross all verisons of the feature
+ * @param {number} version feature version that should be rolled back
  *
  * @returns {Object} Returns calculated inverse feature
  */
@@ -144,8 +144,8 @@ function iterate(db, stream) {
  * retreiving it's history and writing it to disk
  *
  * @param {Object} options options object
- * @param {Number} options.start Delta Start ID
- * @param {Number} options.end Delta End ID
+ * @param {number} options.start Delta Start ID
+ * @param {number} options.end Delta End ID
  *
  * @returns {Promise}
  */
@@ -177,7 +177,7 @@ function cache(options, api) {
             const q = new Q(50);
 
             for (const feat of delta.features.features) {
-                q.defer(async (feat, done) => {
+                q.defer(async(feat, done) => {
                     const history = await getFeatureHistory({
                         feature: feat.id
                     });

--- a/util/revert.js
+++ b/util/revert.js
@@ -146,7 +146,7 @@ function iterate(db, stream) {
  * Given a start/end range for a set of deltas, download
  * each of the deltas, then iterate through each feature,
  * retreiving it's history and writing it to disk
- * 
+ *
  * @private
  *
  * @param {Object} options options object

--- a/util/validateBbox.js
+++ b/util/validateBbox.js
@@ -3,6 +3,8 @@
 /**
  * Accepts a bbox as a string or array, and validates (naive with regards to the Antimeridian)
  *
+ * @private
+ *
  * @param {Array|string} bboxInput Array in the format [minX,minY,maxX,maxY] or string in the format minX,minY,maxX,maxY
  * @returns {string} String in the format minX,minY,maxX,maxY
  */

--- a/util/validateGeojson.js
+++ b/util/validateGeojson.js
@@ -19,6 +19,8 @@ ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-04.json'));
  * @param {boolean} opts.ignoreRHR=false Ignore Right Hand Rule errors
  * @param {Object} opts.schema JSON Schema to validate properties against
  * @param {boolean} opts.ids If false, disable duplicate ID checking
+ *
+ * @return {Stream} transform stream to validate GeoJSON
  */
 function validateGeojson(opts = {}) {
     // Flag to track the feature line number
@@ -60,7 +62,7 @@ function validateGeojson(opts = {}) {
  * Validate a single feature
  *
  * @param {Object|string} line Feature to validate
- * @param {Object} options
+ * @param {Object} options Validation Options
  * @param {boolean} options.ignoreRHR Ignore winding order
  * @param {Function} options.schema AJV Function to validate feature properties against a JSON Schema
  * @param {number} options.linenumber Linenumber to output in error object

--- a/util/validateGeojson.js
+++ b/util/validateGeojson.js
@@ -59,7 +59,7 @@ function validateGeojson(opts = {}) {
 /**
  * Validate a single feature
  *
- * @param {Object|String} line Feature to validate
+ * @param {Object|string} line Feature to validate
  * @param {Object} options
  * @param {boolean} options.ignoreRHR Ignore winding order
  * @param {Function} options.schema AJV Function to validate feature properties against a JSON Schema

--- a/util/validateGeojson.js
+++ b/util/validateGeojson.js
@@ -15,6 +15,8 @@ ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-04.json'));
 /**
  * Ensure geometries are valid before import
  *
+ * @private
+ *
  * @param {Object} opts Options object
  * @param {boolean} opts.ignoreRHR=false Ignore Right Hand Rule errors
  * @param {Object} opts.schema JSON Schema to validate properties against
@@ -60,6 +62,8 @@ function validateGeojson(opts = {}) {
 
 /**
  * Validate a single feature
+ *
+ * @private
  *
  * @param {Object|string} line Feature to validate
  * @param {Object} options Validation Options


### PR DESCRIPTION
Hecate@0.81 simplifies several Custom Authentication settings that HecateJS uses
for determining if extra permissions are needed. The following changes affect this library:
- `webhooks` -> `set` & `get`
- `stats` -> `get`

cc/ @mapbox/search 