### PR TITLE
Continue Import on Error

### DIFF
--- a/lib/import.js
+++ b/lib/import.js
@@ -150,6 +150,8 @@ class Import {
             let total = 0; // Total uploaded line delimited features - output in case of fatal error so the user can resume
             let rl;
 
+            let errors = [];
+
             // This call is optional and won't terminate the upload if it fails,
             // It simply attempts to determine the max upload size constraints of the server
             self.api._.server.get({}, (err, server) => {
@@ -236,6 +238,10 @@ class Import {
 
                     read();
                 });
+
+                if(errors.length > 0) {
+                    return cb(errors);
+                }
             }
 
             /**
@@ -268,13 +274,19 @@ class Import {
                 }, (err, res) => {
                     if (err) {
                         console.error(`Upload Error: Uploaded to Line ${total}`);
-                        return cb(err);
+                        errors.push(JSON.stringify({
+                            line: total,
+                            err
+                        }));
                     }
 
                     if (res.statusCode !== 200) {
                         console.error(`${res.body}`);
                         console.error(`Upload Error: Uploaded to Line ${total}`);
-                        return cb(new Error(JSON.stringify(res.body)));
+                        errors.push(JSON.stringify({
+                            line: total,
+                            err: res.body
+                        }));
                     }
                     return upload_cb();
                 });


### PR DESCRIPTION
Enable the Hecate Import to continue after an error is encountered in a single record.
Return all errors after import is completed.