### PR TITLE
Add query command

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -47,7 +47,8 @@ class Hecate {
             schema: new (require('./lib/schema'))(this),
             server: new (require('./lib/server'))(this),
             import: new (require('./lib/import'))(this),
-            revert: new (require('./lib/revert'))(this)
+            revert: new (require('./lib/revert'))(this),
+            query: new(require('./lib/query'))(this),
         };
 
         // Add Helper Functions
@@ -104,6 +105,7 @@ if (require.main === module) {
         console.error('    bbox            [--help]    Download data via bbox from a given server');
         console.error('    clone           [--help]    Download the complete server dataset');
         console.error('    revert          [--help]    Revert data from an specified delta');
+        console.error('    query           [--help]    Download the server dataset for a SQL query');
         console.error('');
         console.error('<options>');
         console.error('    --version                   Print the current version of the CLI');

--- a/lib/query.js
+++ b/lib/query.js
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const request = require('request');
+const prompt = require('prompt');
+const auth = require('../util/get_auth');
+const EOT = require('../util/eot');
+
+/**
+ * @class Query
+ * @public
+ *
+ * @see {@link https://github.com/mapbox/hecate#downloading-via-query|Hecate Documentation}
+ */
+class Query {
+    /**
+     * Create a new Query Instance
+     *
+     * @param {Hecate} api parent hecate instance
+     */
+    constructor(api) {
+        this.api = api;
+    }
+
+    /**
+     * Print help documentation about the subcommand to stderr
+     */
+    help() {
+        console.error();
+        console.error('Fetch data matching a SQL query from the server');
+        console.error();
+        console.error('Usage: cli.js query <subcommand>');
+        console.error();
+        console.error('<subcommand>:');
+        console.error('    get      Stream LDgeoJSON of the data matching the SQL query');
+        console.error();
+    }
+
+    /**
+     * Query data on a given hecate server
+     *
+     * @param {!Object} options Options for making a request to the hecate /api/data/features endpoint
+     * @param {Stream} [options.output] Stream to write line-delimited GeoJSON to
+     * @param {function} cb (err, res) style callback function
+     *
+     * @return {function} (err, res) style callback
+     */
+    get(options = {}, cb) {
+        const self = this;
+
+        if (!options) options = {};
+
+        if (options.script) {
+            cb = cli;
+
+            options.output = process.stdout;
+
+            return main();
+        } else if (options.cli) {
+            cb = cli;
+
+            prompt.message = '$';
+            prompt.start({
+                stdout: process.stderr
+            });
+
+            let args = [{
+                name: 'query',
+                message: 'SQL query',
+                required: true,
+                type: 'string',
+                default: options.query
+            }];
+
+            if (!self.api.user && self.api.auth_rules && self.api.auth_rules.query.get !== 'public') {
+                args = args.concat(auth(self.api.user));
+            }
+
+            prompt.get(args, (err, argv) => {
+                prompt.stop();
+
+                if (argv.hecate_username) {
+                    self.api.user = {
+                        username: argv.hecate_username,
+                        password: argv.hecate_password
+                    };
+                }
+
+                options.query = argv.query;
+                options.output = process.stdout;
+
+                return main();
+            });
+        } else {
+            return main();
+        }
+
+        /**
+         * Once the options object is populated, make the API request
+         * @private
+         *
+         * @returns {undefined}
+         */
+        function main() {
+            if (!options.query) return cb(new Error('options.query required'));
+            if (!options.output) return cb(new Error('options.output required'));
+
+            request({
+                method: 'GET',
+                url: new URL('/api/data/query', self.api.url),
+                qs: { query: options.query },
+                auth: self.api.user
+            }).on('error', (err) => {
+                return cb(err);
+            }).on('response', (res) => {
+                if (res.statusCode !== 200) return cb(new Error(JSON.stringify(res.body)));
+            }).pipe(new EOT(cb)).pipe(options.output);
+        }
+
+        /**
+         * If in CLI mode, write results to stdout
+         * or throw any errors incurred
+         *
+         * @private
+         *
+         * @param {Error} err [optional] API Error
+         *
+         * @returns {undefined}
+         */
+        function cli(err) {
+            if (err) throw err;
+        }
+    }
+}
+
+module.exports = Query;

--- a/test/lib.import.test.js
+++ b/test/lib.import.test.js
@@ -19,7 +19,7 @@ test('Basic Import Test', (t) => {
                     max_size: 20971520
                 }
             },
-            version: "0.82.1"
+            version: '0.82.1'
         })
         .get('/api/schema').reply(200,
             JSON.parse(fs.readFileSync(path.resolve(__dirname, './fixtures/valid-geojson.schema')))

--- a/test/util.revert.test.js
+++ b/test/util.revert.test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const os = require('os');
 const test = require('tape');
 const revert = require('../util/revert');
 
@@ -171,7 +172,7 @@ test('Revert#createCache', (t) => {
     t.equals(db.open, true);
     t.equals(db.memory, false);
     t.equals(db.readonly, false);
-    t.ok(/\/tmp\/revert\..*.\.sqlite/.test(db.name));
-
+    const dbPathRE = new RegExp(`${os.tmpdir().replace(/[.*+\-?^${}()|[\]\\]/g, '\\$&')}\/revert\.*.\.sqlite`);
+    t.ok(dbPathRE.test(db.name));
     t.end();
 });

--- a/util/validateGeojson.js
+++ b/util/validateGeojson.js
@@ -55,7 +55,7 @@ function validateGeojson(opts = {}) {
             throw new Error('Invalid Feature');
         }
 
-        return cb(null, feat+'\n');
+        return cb(null, feat + '\n');
     });
 
 }


### PR DESCRIPTION
The Hecate API supports a query interface that allows SQL queries over the geo table. The query API is currently exposed in the Hecate UI, but is not present in the cli.

There were a couple of lint and test issues that needed to be fixed before I could test these changes, so those fixes are here as well.

/cc @mapbox/search-addresses 